### PR TITLE
Apple rebrands "OS X" as "macOS"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,11 +47,11 @@ if(OVERRIDE MATCHES "ON")
   list(APPEND mi_defines MI_MALLOC_OVERRIDE)
   if(APPLE)
     if(INTERPOSE MATCHES "ON")
-      # use interpose on MacOSX
+      # use interpose on macOS
       message(STATUS "  Use interpose to override malloc (INTERPOSE=ON)")
       list(APPEND mi_defines MI_INTERPOSE)
     else()
-      # use zone's on MacOSX
+      # use zone's on macOS
       message(STATUS "  Use zone's to override malloc (INTERPOSE=OFF)")
       list(APPEND mi_sources src/alloc-override-osx.c)
     endif()

--- a/doc/mimalloc-doc.h
+++ b/doc/mimalloc-doc.h
@@ -648,7 +648,7 @@ The `mimalloc` project builds a static library (in `out/msvc-x64`), while the
 `mimalloc-override` project builds a DLL for overriding malloc
 in the entire program.
 
-## MacOSX, Linux, BSD, etc.
+## macOS, Linux, BSD, etc.
 
 We use [`cmake`](https://cmake.org)<sup>1</sup> as the build system:
 
@@ -772,14 +772,14 @@ Overriding the standard `malloc` can be done either _dynamically_ or _statically
 
 This is the recommended way to override the standard malloc interface.
 
-### Unix, BSD, MacOSX
+### Unix, BSD, macOS
 
 On these systems we preload the mimalloc shared
 library so all calls to the standard `malloc` interface are
 resolved to the _mimalloc_ library.
 
 - `env LD_PRELOAD=/usr/lib/libmimalloc.so myprogram` (on Linux, BSD, etc.)
-- `env DYLD_INSERT_LIBRARIES=usr/lib/libmimalloc.dylib myprogram` (On MacOSX)
+- `env DYLD_INSERT_LIBRARIES=usr/lib/libmimalloc.dylib myprogram` (On macOS)
 
   Note certain security restrictions may apply when doing this from
   the [shell](https://stackoverflow.com/questions/43941322/dyld-insert-libraries-ignored-when-calling-application-through-bash).

--- a/docs/build.html
+++ b/docs/build.html
@@ -104,7 +104,7 @@ $(document).ready(function(){initNavTree('build.html','');});
 <div class="contents">
 <div class="textblock"><p>Checkout the sources from Github: </p><div class="fragment"><div class="line">git clone https:<span class="comment">//github.com/microsoft/mimalloc</span></div></div><!-- fragment --><h2>Windows</h2>
 <p>Open <code>ide/vs2017/mimalloc.sln</code> in Visual Studio 2017 and build. The <code>mimalloc</code> project builds a static library (in <code>out/msvc-x64</code>), while the <code>mimalloc-override</code> project builds a DLL for overriding malloc in the entire program.</p>
-<h2>MacOSX, Linux, BSD, etc.</h2>
+<h2>macOS, Linux, BSD, etc.</h2>
 <p>We use <a href="https://cmake.org"><code>cmake</code></a><sup>1</sup> as the build system:</p>
 <div class="fragment"><div class="line">&gt; mkdir -p out/release</div><div class="line">&gt; cd out/release</div><div class="line">&gt; cmake ../..</div><div class="line">&gt; make</div></div><!-- fragment --><p> This builds the library as a shared (dynamic) library (<code>.so</code> or <code>.dylib</code>), a static library (<code>.a</code>), and as a single object file (<code>.o</code>).</p>
 <p><code>&gt; sudo make install</code> (install the library and header files in <code>/usr/local/lib</code> and <code>/usr/local/include</code>)</p>

--- a/docs/overrides.html
+++ b/docs/overrides.html
@@ -105,11 +105,11 @@ $(document).ready(function(){initNavTree('overrides.html','');});
 <div class="textblock"><p>Overriding the standard <code>malloc</code> can be done either <em>dynamically</em> or <em>statically</em>.</p>
 <h2>Dynamic override</h2>
 <p>This is the recommended way to override the standard malloc interface.</p>
-<h3>Unix, BSD, MacOSX</h3>
+<h3>Unix, BSD, macOS</h3>
 <p>On these systems we preload the mimalloc shared library so all calls to the standard <code>malloc</code> interface are resolved to the <em>mimalloc</em> library.</p>
 <ul>
 <li><code>env LD_PRELOAD=/usr/lib/libmimalloc.so myprogram</code> (on Linux, BSD, etc.)</li>
-<li><p class="startli"><code>env DYLD_INSERT_LIBRARIES=usr/lib/libmimalloc.dylib myprogram</code> (On MacOSX)</p>
+<li><p class="startli"><code>env DYLD_INSERT_LIBRARIES=usr/lib/libmimalloc.dylib myprogram</code> (On macOS)</p>
 <p class="startli">Note certain security restrictions may apply when doing this from the <a href="https://stackoverflow.com/questions/43941322/dyld-insert-libraries-ignored-when-calling-application-through-bash">shell</a>.</p>
 </li>
 </ul>

--- a/include/mimalloc-internal.h
+++ b/include/mimalloc-internal.h
@@ -146,7 +146,7 @@ extern mi_decl_thread mi_heap_t* _mi_heap_default;  // default heap to allocate 
 
 static inline mi_heap_t* mi_get_default_heap() {
 #ifdef MI_TLS_RECURSE_GUARD
-  // on some platforms, like MacOSX, the dynamic loader calls `malloc`
+  // on some platforms, like macOS, the dynamic loader calls `malloc`
   // to initialize thread local data. To avoid recursion, we need to avoid
   // accessing the thread local `_mi_default_heap` until our module is loaded
   // and use the statically allocated main heap until that time.
@@ -300,7 +300,7 @@ static inline uintptr_t _mi_thread_id() mi_attr_noexcept {
   #if defined(__i386__)
   __asm__("movl %%gs:0, %0" : "=r" (tid) : : );  // 32-bit always uses GS
   #elif defined(__MACH__)
-  __asm__("movq %%gs:0, %0" : "=r" (tid) : : );  // x86_64 MacOSX uses GS
+  __asm__("movq %%gs:0, %0" : "=r" (tid) : : );  // x86_64 macOS uses GS
   #elif defined(__x86_64__)
   __asm__("movq %%fs:0, %0" : "=r" (tid) : : );  // x86_64 Linux, BSD uses FS
   #elif defined(__arm__)

--- a/readme.md
+++ b/readme.md
@@ -61,7 +61,7 @@ The `mimalloc` project builds a static library (in `out/msvc-x64`), while the
 `mimalloc-override` project builds a DLL for overriding malloc
 in the entire program.
 
-## MacOSX, Linux, BSD, etc.
+## macOS, Linux, BSD, etc.
 
 We use [`cmake`](https://cmake.org)<sup>1</sup> as the build system:
 
@@ -182,14 +182,14 @@ Overriding the standard `malloc` can be done either _dynamically_ or _statically
 
 This is the recommended way to override the standard malloc interface.
 
-### Unix, BSD, MacOSX
+### Unix, BSD, macOS
 
 On these systems we preload the mimalloc shared
 library so all calls to the standard `malloc` interface are
 resolved to the _mimalloc_ library.
 
 - `env LD_PRELOAD=/usr/lib/libmimalloc.so myprogram` (on Linux, BSD, etc.)
-- `env DYLD_INSERT_LIBRARIES=usr/lib/libmimalloc.dylib myprogram` (On MacOSX)
+- `env DYLD_INSERT_LIBRARIES=usr/lib/libmimalloc.dylib myprogram` (On macOS)
 
   Note certain security restrictions may apply when doing this from
   the [shell](https://stackoverflow.com/questions/43941322/dyld-insert-libraries-ignored-when-calling-application-through-bash).

--- a/src/alloc-override-osx.c
+++ b/src/alloc-override-osx.c
@@ -11,11 +11,11 @@ terms of the MIT license. A copy of the license can be found in the file
 #if defined(MI_MALLOC_OVERRIDE) 
 
 #if !defined(__APPLE__)
-#error "this file should only be included on MacOSX"
+#error "this file should only be included on macOS"
 #endif
 
 /* ------------------------------------------------------
-   Override system malloc on MacOSX
+   Override system malloc on macOS
    This is done through the malloc zone interface.
 ------------------------------------------------------ */
 
@@ -161,7 +161,7 @@ static malloc_zone_t* mi_get_default_zone()
 }
 
 
-static void __attribute__((constructor)) _mi_macosx_override_malloc()
+static void __attribute__((constructor)) _mi_macos_override_malloc()
 {
   static malloc_introspection_t intro;
   memset(&intro, 0, sizeof(intro));


### PR DESCRIPTION
In 2012, with the release of OS X 10.8 Mountain Lion, the name of the
system was shortened from Mac OS X to OS X. In 2016, with the release
of macOS 10.12 Sierra, the name was changed from OS X to macOS to
streamline it with the branding of Apple's other primary operating
systems: iOS, watchOS, and tvOS.

Reference: https://en.wikipedia.org/wiki/MacOS