### PR TITLE
Port to WebAssembly

### DIFF
--- a/include/mimalloc-atomic.h
+++ b/include/mimalloc-atomic.h
@@ -196,6 +196,11 @@ static inline void mi_atomic_write(volatile uintptr_t* p, uintptr_t x) {
     asm volatile("yield");
   }
 #endif
+#elif defined(__wasi__)
+  #include <sched.h>
+  static inline void mi_atomic_yield() {
+    sched_yield();
+  }
 #else
   #include <unistd.h>
   static inline void mi_atomic_yield(void) {

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -442,6 +442,7 @@ char* mi_strndup(const char* s, size_t n) mi_attr_noexcept {
   return mi_heap_strndup(mi_get_default_heap(),s,n);
 }
 
+#ifndef __wasi__
 // `realpath` using mi_malloc
 #ifdef _WIN32
 #ifndef PATH_MAX
@@ -498,6 +499,7 @@ char* mi_heap_realpath(mi_heap_t* heap, const char* fname, char* resolved_name) 
 char* mi_realpath(const char* fname, char* resolved_name) mi_attr_noexcept {
   return mi_heap_realpath(mi_get_default_heap(),fname,resolved_name);
 }
+#endif
 
 
 #ifdef __cplusplus

--- a/src/stats.c
+++ b/src/stats.c
@@ -407,7 +407,11 @@ static void mi_process_info(double* utime, double* stime, size_t* peak_rss, size
 }
 
 #else
+#ifndef __wasi__
+// WebAssembly instances are not processes
 #pragma message("define a way to get process info")
+#endif
+
 static void mi_process_info(double* utime, double* stime, size_t* peak_rss, size_t* page_faults, size_t* page_reclaim, size_t* peak_commit) {
   *peak_rss = 0;
   *page_faults = 0;


### PR DESCRIPTION
This makes mimalloc compatible with the WebAssembly Standard Interface.

I'm considering it as a dlmalloc replacement for wasi-libc, and have been successfully running it in this scenario.