### PR TITLE
Use clock_gettime() instead of timespec_get()

### DIFF
--- a/src/stats.c
+++ b/src/stats.c
@@ -312,10 +312,10 @@ static double mi_clock_now() {
 }
 #else
 #include <time.h>
-#ifdef TIME_UTC
+#ifdef CLOCK_REALTIME
 static double mi_clock_now() {
   struct timespec t;
-  timespec_get(&t, TIME_UTC);
+  clock_gettime(CLOCK_REALTIME, &t);
   return (double)t.tv_sec + (1.0e-9 * (double)t.tv_nsec);
 }
 #else


### PR DESCRIPTION
clock_gettime(CLOCK_REALTIME, &ts) is equivalent to timespec_get(&ts,
TIME_UTC) in C11.

It has the advantage that avoids the following building error when building
with macOS:

  warning: 'timespec_get' is only available on macOS 10.15 or newer
   [-Wunguarded-availability-new]