### PR TITLE
Return EINVAL when alignment is not a power of 2 to match posix standard

### DIFF
--- a/src/alloc-override.c
+++ b/src/alloc-override.c
@@ -135,7 +135,7 @@ int posix_memalign(void** p, size_t alignment, size_t size) {
   // TODO: the spec says we should return EINVAL also if alignment is not a power of 2.
   // The spec also dictates we should not modify `*p` on an error. (issue#27)
   // <http://man7.org/linux/man-pages/man3/posix_memalign.3.html>
-  if (alignment % sizeof(void*) != 0) return EINVAL;  // no `p==NULL` check as it is declared as non-null
+  if ((alignment % sizeof(void*))||(alignment % 2)  != 0) return EINVAL;  // no `p==NULL` check as it is declared as non-null
   void* q = mi_malloc_aligned(size, alignment);
   if (q==NULL && size != 0) return ENOMEM;
   *p = q;


### PR DESCRIPTION
Solve the todo in alloc-override.c