### PR TITLE
Clarify the comment about Linux distributions

### DIFF
--- a/src/alloc-override.c
+++ b/src/alloc-override.c
@@ -168,7 +168,7 @@ void* reallocarray( void* p, size_t count, size_t size ) {  // BSD
 }
 
 #if defined(__GLIBC__) && defined(__linux__)
-  // forward __libc interface (needed for redhat linux)
+  // forward __libc interface (needed for glibc-based Linux distributions)
   void* __libc_malloc(size_t size)                  MI_FORWARD1(mi_malloc,size)
   void* __libc_calloc(size_t count, size_t size)    MI_FORWARD2(mi_calloc,count,size)
   void* __libc_realloc(void* p, size_t size)        MI_FORWARD2(mi_realloc,p,size)


### PR DESCRIPTION
Red Hat Linux was discontinued by Red Hat in 2003. It would make sense
to address glibc-based Linux distributions rather than Red Hat Linux.

Reference: https://en.wikipedia.org/wiki/Red_Hat_Linux