### PR TITLE
Consisten small block alignment

### DIFF
--- a/src/page.c
+++ b/src/page.c
@@ -516,9 +516,9 @@ static void mi_page_init(mi_heap_t* heap, mi_page_t* page, size_t block_size, mi
   mi_assert(segment != NULL);
   // set fields
   size_t page_size;
-  _mi_segment_page_start(segment, page, &page_size);
-  page->block_size = block_size;
   mi_assert_internal(block_size>0);
+  page->block_size = block_size;
+  _mi_segment_page_start(segment, page, &page_size);
   mi_assert_internal(page_size / block_size < (1L<<16));
   page->reserved = (uint16_t)(page_size / block_size);
   page->cookie = _mi_heap_random(heap) | 1;  


### PR DESCRIPTION
After I had noticed that some blocks in the size of small powers of two are not perfectly aligned to them as expected, I looked for the reason and found it in the special treatment of the first trimmed page in the segment. Since a consistent behavior of the first page of a segment to the other pages seems desirable to me, I suggest to adjust the alignment there accordingly.