### PR TITLE
Avoid system environment path in find_package

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,7 +13,7 @@ if (NOT CMAKE_BUILD_TYPE)
 endif()
 
 # Import mimalloc (if installed)
-find_package(mimalloc 1.0 REQUIRED)
+find_package(mimalloc 1.0 REQUIRED NO_SYSTEM_ENVIRONMENT_PATH)
 
 # Tests
 add_executable(static-override  main-override.c)


### PR DESCRIPTION
When I was building tests, an error message showed up
```
CMake Error at /home/afcidk/mimalloc/cmake/mimalloc-config.cmake:1 (include):
  include could not find load file:

    /home/afcidk/mimalloc/cmake/mimalloc.cmake
Call Stack (most recent call first):
  CMakeLists.txt:16 (find_package)

-- Configuring incomplete, errors occurred!
```
The CMakeLists seemed to be using the `cmake` directory in the project root directory, so it cannot find `mimalloc.cmake`. Instead,  it should use the installed library in `/usr/local`, so I explicity specify the path and set `NO_DEFAULT_PATH` to it.