### PR TITLE
Suppressed the new GCC 9 -Wmissing-attributes warnings

### DIFF
--- a/src/alloc-override.c
+++ b/src/alloc-override.c
@@ -25,7 +25,11 @@ terms of the MIT license. A copy of the license can be found in the file
 
 #if (defined(__GNUC__) || defined(__clang__)) && !defined(__MACH__)
   // use aliasing to alias the exported function to one of our `mi_` functions
+#if (defined(__GNUC__) && __GNUC__ >= 9) 
+  #define MI_FORWARD(fun)      __attribute__((alias(#fun), used, visibility("default"), copy(fun)))
+#else
   #define MI_FORWARD(fun)      __attribute__((alias(#fun), used, visibility("default")))
+#endif
   #define MI_FORWARD1(fun,x)   MI_FORWARD(fun)
   #define MI_FORWARD2(fun,x,y) MI_FORWARD(fun)
   #define MI_FORWARD0(fun,x)   MI_FORWARD(fun)


### PR DESCRIPTION
With the new release of the GCC 9 compiler the operation of -Wmissing-attributes warnings has also been extended to aliases: this causes a warnings if the alias has less attributes than its target.

This warnings does not actually indicate a problem in the mimalloc code and you could safely ignore it by adding "-Wno-missing-attributes" to the CFLAGS, however I was not going to use a "hack" to hide the warning when compiling alloc-override .c

So this patch solves the problem simply by using an attribute (present only in GCC> = 9) that copies the attributes of another function, since this attribute is exclusive only for GCC 9 (or later) I had to use a simple precompiler instruction to add the "copy" attribute only with GCC 9.

More information about the "copy" attribute is available here: https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-copy-function-attribute

The warnings that came out BEFORE the patch:
```
mimalloc/src/alloc-override.c:172:9: warning: ‘__libc_malloc’ specifies less restrictive attributes than its target ‘mi_malloc’: ‘alloc_size’, ‘malloc’ [-Wmissing-attributes]
  172 |   void* __libc_malloc(size_t size)                  MI_FORWARD1(mi_malloc,size);
      |         ^~~~~~~~~~~~~
In file included from mimalloc/src/static.c:21:
mimalloc/src/alloc.c:83:21: note: ‘__libc_malloc’ target declared here
   83 | extern inline void* mi_malloc(size_t size) mi_attr_noexcept {
      |                     ^~~~~~~~~
In file included from mimalloc/src/alloc.c:14,
                 from mimalloc/src/static.c:21:
```

The build output AFTER the patch:
```
Scanning dependencies of target mimalloc-static
[  4%] Building C object CMakeFiles/mimalloc-static.dir/src/stats.c.o
[  9%] Building C object CMakeFiles/mimalloc-static.dir/src/os.c.o
[ 14%] Building C object CMakeFiles/mimalloc-static.dir/src/segment.c.o
[ 19%] Building C object CMakeFiles/mimalloc-static.dir/src/page.c.o
[ 23%] Building C object CMakeFiles/mimalloc-static.dir/src/alloc.c.o
[ 28%] Building C object CMakeFiles/mimalloc-static.dir/src/alloc-aligned.c.o
[ 33%] Building C object CMakeFiles/mimalloc-static.dir/src/heap.c.o
[ 38%] Building C object CMakeFiles/mimalloc-static.dir/src/options.c.o
[ 42%] Building C object CMakeFiles/mimalloc-static.dir/src/init.c.o
[ 47%] Linking C static library libmimalloc.a
[ 47%] Built target mimalloc-static
Scanning dependencies of target mimalloc-obj
[ 52%] Building C object CMakeFiles/mimalloc-obj.dir/src/static.c.o
[ 52%] Built target mimalloc-obj
Scanning dependencies of target mimalloc
[ 57%] Building C object CMakeFiles/mimalloc.dir/src/stats.c.o
[ 61%] Building C object CMakeFiles/mimalloc.dir/src/os.c.o
[ 66%] Building C object CMakeFiles/mimalloc.dir/src/segment.c.o
[ 71%] Building C object CMakeFiles/mimalloc.dir/src/page.c.o
[ 76%] Building C object CMakeFiles/mimalloc.dir/src/alloc.c.o
[ 80%] Building C object CMakeFiles/mimalloc.dir/src/alloc-aligned.c.o
[ 85%] Building C object CMakeFiles/mimalloc.dir/src/heap.c.o
[ 90%] Building C object CMakeFiles/mimalloc.dir/src/options.c.o
[ 95%] Building C object CMakeFiles/mimalloc.dir/src/init.c.o
[100%] Linking C shared library libmimalloc.so
[100%] Built target mimalloc
```
Finally the annoying warnings are gone!