### PR TITLE
Partially reduced division in mi_heap_area_visit_blocks()

### DIFF
--- a/src/heap.c
+++ b/src/heap.c
@@ -386,6 +386,31 @@ bool mi_check_owned(const void* p) {
   return mi_heap_check_owned(mi_get_default_heap(), p);
 }
 
+// find first set: return the index of the lowest set bit.
+static inline uint8_t mi_ffs32(uint32_t x);
+
+#if defined(_MSC_VER)
+#include <intrin.h>
+static inline uint8_t mi_ffs32(uint32_t x) {
+  uint32_t idx;
+  if (_BitScanForward(&idx, x) != 0)return idx;
+
+  return 0;
+}
+#elif defined(__GNUC__) || defined(__clang__)
+static inline uint8_t mi_ffs32(uint32_t x) {
+  return (__builtin_ffs(x))-1;
+}
+#else
+static inline uint8_t mi_ffs32(uint32_t x) {
+  static const uint8_t debruijn[32] = {
+  0, 1, 28, 2, 29, 14, 24, 3, 30, 22, 20, 15, 25, 17, 4, 8, 
+  31, 27, 13, 23, 21, 19, 16, 7, 26, 12, 18, 6, 11, 5, 10, 9
+};
+  return debruijn[((uint32_t)(x&-x)*0x077CB531U) >> 27];
+}
+#endif
+
 /* -----------------------------------------------------------
   Visit all heap blocks and areas
   Todo: enable visiting abandoned pages, and

--- a/src/heap.c
+++ b/src/heap.c
@@ -455,7 +455,19 @@ static bool mi_heap_area_visit_blocks(const mi_heap_area_ex_t* xarea, mi_block_v
     mi_assert_internal((uint8_t*)block >= pstart && (uint8_t*)block < (pstart + psize));
     size_t offset = (uint8_t*)block - pstart;
     mi_assert_internal(offset % page->block_size == 0);
-    size_t blockidx = offset / page->block_size;  // Todo: avoid division?
+    size_t blockidx;
+    size_t divident = page->block_size;
+    blockidx = offset >> mi_ffs32(divident);
+    divident >>= mi_ffs32(divident);
+    switch (divident)
+    {
+    case 3: blockidx/=3; 
+      break;
+    case 5: blockidx/=5;
+      break;
+    case 7: blockidx/=7;
+      break;
+    }
     mi_assert_internal( blockidx < MI_MAX_BLOCKS);
     size_t bitidx = (blockidx / sizeof(uintptr_t));
     size_t bit = blockidx - (bitidx * sizeof(uintptr_t));


### PR DESCRIPTION
I tried to avoid divisions in mi_heap_area_visit_blocks(), but, I haven't found a way to avoid all of them.
However, I do found a way to reduce some of them!

First of all, all the possible values of block_size are enumerated in MI_PAGE_QUEUES_EMPTY,
-  (1 or 2 or 3 or 4)
-  (5 or 6 or 7 or 8)*(2^n)  n from 1 to 14

We all knew that when the block_size is huge, it'll have a  special size.
But, If the block_size is huge, its page capacity will be 1 which won't be considered.

I compared 3 different ways to get `blockidx`:

### Only reduce divisions for POWER OF 2s
    size_t blockidx;
    if(page->block_size && (page->block_size -1)== 0){
      blockidx = offset>> mi_ffs32(page->block_size);
    }else{
      blockidx = offset/=page->block_size;
    }

### Substitute divisions with constant divisions
    size_t blockidx;
    size_t divident = page->block_size;
    blockidx = offset >> mi_ffs32(divident);
    divident >>= mi_ffs32(divident);
    switch (divident)
    {
    case 3: blockidx/=3; 
      break;
    case 5: blockidx/=5;
      break;
    case 7: blockidx/=7;
      break
     }

### Original
size_t blockidx = offset/=page->block_size;

## Experiment
Environment
- MacOS Darwin Kernel Version 18.6.0

I tested with 3 situations below:
-  The repeat of 100000 times is for convenience of observation.

### details
* By using mi_stats_print(OF), I've got a bunch of elapsed time(12 in pow(2) test, 50 in other 2) every turn.

* For each condition, I run 100 times for each test to each strategy.

* For 100 * 12 or 100 * 50 elapsed time values, I removed 5% of extreme values, and get the average of the rests.

* The reason I don't simply use the [mimalloc-bench](https://github.com/daanx/mimalloc-bench) is that I'm not sure in each test how many partitions does mi_heap_area_visit_block() involved.

### block_size form 1025 to 2048

    int bs;
    for(int repeat = 0; repeat < 50 ; repeat++){
        bs = rand()%1024+1025;
        mi_stats_reset();
        void* heap1 = mi_heap_new();
        mi_heap_calloc(heap1, 1, bs);
        for(int i = 1; i<100000; i+=1){
            mi_heap_visit_blocks(heap1, 1, visitor,NULL);
        }
        mi_stats_print(OF);
    }


- original 
average time of 100000 repeats: 0.01480 second
- reduce divisions for POWER OF 2s
average time of 100000 repeats: 0.01598 second
- constant divisions
average time of 100000 repeats: 0.01534 second

When the block_size is huge the amount of block will relatively decrease,. So, performances of these 3 strategies are alike when the amount of block is small.


### block_size form 1 to 1024
    int bs;
    for(int repeat = 0; repeat < 50 ; repeat++){
        bs = rand()%1024+1;
        mi_stats_reset();
        void* heap1 = mi_heap_new();
        mi_heap_calloc(heap1, 1, bs);
        for(int i = 1; i<100000; i+=1){
            mi_heap_visit_blocks(heap1, 1, visitor,NULL);
        }
        mi_stats_print(OF);
    }

- original 
average time of 100000 repeats: 0.03901 second
- reduce division for POWER OF 2s
average time of 100000 repeats: 0.02683 second
- constant division
average time of 100000 repeats: 0.01884 second

In this situation, the amount of block_size will be far bigger than the last test, and we can see the "constant division" strategy starts to show its strength.
The reason why "reduce division for Power of 2s" is better than original strategy here is that even if the block_size is randomly given the number of pure pow2 block_size page is still huge.

### block_size are power of 2
    for(int bs = 1; bs < 2049; bs *= 2){
        mi_stats_reset();
        void* heap1 = mi_heap_new();
        mi_heap_calloc(heap1, 1, bs);
        for(int i = 1; i<100000; i+=1){
            mi_heap_visit_blocks(heap1, 1, visitor,NULL);
        }
        mi_stats_print(OF);
    }

- original 
average time of 100000 repeats: 0.191330 second
- reduce divisions for POWER OF 2s
average time of 100000 repeats: 0.06825 second
- constant divisions
average time of 100000 repeats: 0.06758 second

### the Time Distribution if the block size is power of 2
![Figure_1](https://user-images.githubusercontent.com/37362730/60713209-35790d00-9f4b-11e9-9799-8e309027847d.png)


## Here is the conclusion:
The results show that the "constant division" strategy did good jobs in all the tests, on the other hand, the other 2 strategies have their weakness in some situations.

So, I recommended the 'constant divisions' strategy for tiny improvement for performance!





