### PR TITLE
Constify the parameters of some functions that can become it

### DIFF
--- a/include/mimalloc-internal.h
+++ b/include/mimalloc-internal.h
@@ -81,7 +81,7 @@ void       _mi_stats_done(mi_stats_t* stats);
 void*       _mi_page_malloc(mi_heap_t* heap, mi_page_t* page, size_t size) mi_attr_noexcept;  // called from `_mi_malloc_generic`
 void*       _mi_heap_malloc_zero(mi_heap_t* heap, size_t size, bool zero);
 void*       _mi_realloc_zero(void* p, size_t size, bool zero);
-mi_block_t* _mi_page_ptr_unalign(const mi_segment_t* segment, const mi_page_t* page, void* p);
+mi_block_t* _mi_page_ptr_unalign(const mi_segment_t* segment, const mi_page_t* page, const void* p);
 void        _mi_free_delayed_block(mi_block_t* block);
 
 #if MI_DEBUG>1

--- a/include/mimalloc.h
+++ b/include/mimalloc.h
@@ -104,7 +104,7 @@ mi_decl_export mi_decl_allocator void* mi_reallocf(void* p, size_t newsize)     
 mi_decl_export mi_decl_allocator void* mi_rezalloc(void* p, size_t newsize)             mi_attr_noexcept mi_attr_malloc mi_attr_alloc_size(2);
 mi_decl_export mi_decl_allocator void* mi_recalloc(void* p, size_t count, size_t size)  mi_attr_noexcept mi_attr_malloc mi_attr_alloc_size2(2,3);
 
-mi_decl_export size_t mi_usable_size(void* p)   mi_attr_noexcept;
+mi_decl_export size_t mi_usable_size(const void* p)   mi_attr_noexcept;
 mi_decl_export size_t mi_good_size(size_t size) mi_attr_noexcept;
 
 mi_decl_export void mi_collect(bool force)    mi_attr_noexcept;
@@ -117,7 +117,7 @@ mi_decl_export void mi_thread_done(void)      mi_attr_noexcept;
 mi_decl_export void mi_thread_stats_print(FILE* out) mi_attr_noexcept;
 
 typedef void (mi_deferred_free_fun)(bool force, unsigned long long heartbeat);
-mi_decl_export void mi_register_deferred_free(mi_deferred_free_fun* deferred_free) mi_attr_noexcept;
+mi_decl_export void mi_register_deferred_free(const mi_deferred_free_fun* deferred_free) mi_attr_noexcept;
 
 
 // ------------------------------------------------------
@@ -186,9 +186,9 @@ typedef struct mi_heap_area_s {
   size_t block_size;  // size in bytes of each block
 } mi_heap_area_t;
 
-typedef bool (mi_block_visit_fun)(const mi_heap_t* heap, const mi_heap_area_t* area, void* block, size_t block_size, void* arg);
+typedef bool (mi_block_visit_fun)(const mi_heap_t* heap, const mi_heap_area_t* area, void* block, size_t block_size, const void* arg);
 
-mi_decl_export bool mi_heap_visit_blocks(const mi_heap_t* heap, bool visit_all_blocks, mi_block_visit_fun* visitor, void* arg);
+mi_decl_export bool mi_heap_visit_blocks(const mi_heap_t* heap, bool visit_all_blocks, mi_block_visit_fun* visitor, const void* arg);
 
 // ------------------------------------------------------
 // Convenience

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -177,7 +177,7 @@ static inline void _mi_free_block(mi_page_t* page, bool local, mi_block_t* block
 
 
 // Adjust a block that was allocated aligned, to the actual start of the block in the page.
-mi_block_t* _mi_page_ptr_unalign(const mi_segment_t* segment, const mi_page_t* page, void* p) {
+mi_block_t* _mi_page_ptr_unalign(const mi_segment_t* segment, const mi_page_t* page, const void* p) {
   mi_assert_internal(page!=NULL && p!=NULL);
   size_t diff   = (uint8_t*)p - _mi_page_start(segment, page, NULL);
   size_t adjust = (diff % page->block_size);
@@ -256,7 +256,7 @@ void _mi_free_delayed_block(mi_block_t* block) {
 }
 
 // Bytes available in a block
-size_t mi_usable_size(void* p) mi_attr_noexcept {
+size_t mi_usable_size(const void* p) mi_attr_noexcept {
   if (p==NULL) return 0;
   const mi_segment_t* segment = _mi_ptr_segment(p);
   const mi_page_t* page = _mi_segment_page_of(segment,p);

--- a/src/page.c
+++ b/src/page.c
@@ -642,7 +642,7 @@ static inline mi_page_t* mi_find_free_page(mi_heap_t* heap, size_t size) {
   a certain number of allocations.
 ----------------------------------------------------------- */
 
-static mi_deferred_free_fun* deferred_free = NULL;
+static const mi_deferred_free_fun* deferred_free = NULL;
 
 void _mi_deferred_free(mi_heap_t* heap, bool force) {
   heap->tld->heartbeat++;
@@ -651,7 +651,7 @@ void _mi_deferred_free(mi_heap_t* heap, bool force) {
   }
 }
 
-void mi_register_deferred_free(mi_deferred_free_fun* fn) mi_attr_noexcept {
+void mi_register_deferred_free(const mi_deferred_free_fun* fn) mi_attr_noexcept {
   deferred_free = fn;
 }
 


### PR DESCRIPTION
Using the type qualifier const makes the code easier to understand
avoiding misunderstandings during programming and allows the user
who uses the mimalloc ABI to immediately identify those functions
that change the variables passed to the functions.