### PR TITLE
Use bitwise operation to divide constant

### DIFF
--- a/include/mimalloc-internal.h
+++ b/include/mimalloc-internal.h
@@ -243,7 +243,7 @@ static inline bool mi_page_all_used(mi_page_t* page) {
 // is more than 7/8th of a page in use?
 static inline bool mi_page_mostly_used(const mi_page_t* page) {
   if (page==NULL) return true;
-  uint16_t frac = page->reserved / 8U;
+  uint16_t frac = page->reserved >> 3;
   return (page->reserved - page->used + page->thread_freed < frac);
 }
 

--- a/src/alloc-aligned.c
+++ b/src/alloc-aligned.c
@@ -90,7 +90,7 @@ static void* mi_realloc_zero_aligned_at(void* p, size_t newsize, size_t alignmen
   if (alignment <= sizeof(uintptr_t)) return _mi_realloc_zero(p,newsize,zero);
   if (p == NULL) return mi_malloc_zero_aligned_at(newsize,alignment,offset,zero);
   size_t size = mi_usable_size(p);
-  if (newsize <= size && newsize >= (size - (size / 2))
+  if (newsize <= size && newsize >= (size - (size >> 1))
       && (((uintptr_t)p + offset) % alignment) == 0) {
     return p;  // reallocation still fits, is aligned and not more than 50% waste
   }

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -326,7 +326,7 @@ void* mi_expand(void* p, size_t newsize) mi_attr_noexcept {
 void* _mi_realloc_zero(void* p, size_t newsize, bool zero) {
   if (p == NULL) return _mi_heap_malloc_zero(mi_get_default_heap(),newsize,zero);
   size_t size = mi_usable_size(p);
-  if (newsize <= size && newsize >= (size / 2)) {
+  if (newsize <= size && newsize >= (size >> 1)) {
     return p;  // reallocation still fits and not more than 50% waste
   }
   void* newp = mi_malloc(newsize); // maybe in another heap

--- a/src/segment.c
+++ b/src/segment.c
@@ -681,7 +681,7 @@ static mi_page_t* mi_segment_huge_page_alloc(size_t size, mi_segments_tld_t* tld
 
 mi_page_t* _mi_segment_page_alloc(size_t block_size, mi_segments_tld_t* tld, mi_os_tld_t* os_tld) {
   mi_page_t* page;
-  if (block_size < MI_SMALL_PAGE_SIZE / 8)
+  if (block_size < MI_SMALL_PAGE_SIZE >> 3)
     // smaller blocks than 8kb (assuming MI_SMALL_PAGE_SIZE == 64kb)
     page = mi_segment_small_page_alloc(tld,os_tld);
   else if (block_size < (MI_LARGE_SIZE_MAX - sizeof(mi_segment_t)))


### PR DESCRIPTION
For unsigned intergers, we could use bitwise operation for dividing power of 2 constants.