### PR TITLE
Enforce mi_stat wrapper for performance and consistency

### DIFF
--- a/include/mimalloc-types.h
+++ b/include/mimalloc-types.h
@@ -341,7 +341,7 @@ void _mi_stat_increase(mi_stat_count_t* stat, size_t amount);
 void _mi_stat_decrease(mi_stat_count_t* stat, size_t amount);
 void _mi_stat_counter_increase(mi_stat_counter_t* stat, size_t amount);
 
-#if (MI_STAT)
+#if MI_STAT>0
 #define mi_stat_increase(stat,amount)         _mi_stat_increase( &(stat), amount)
 #define mi_stat_decrease(stat,amount)         _mi_stat_decrease( &(stat), amount)
 #define mi_stat_counter_increase(stat,amount) _mi_stat_counter_increase( &(stat), amount)

--- a/src/init.c
+++ b/src/init.c
@@ -334,7 +334,7 @@ void mi_thread_init(void) mi_attr_noexcept
   // don't further initialize for the main thread
   if (_mi_is_main_thread()) return;
 
-  _mi_stat_increase(&mi_get_default_heap()->tld->stats.threads, 1);
+  mi_stat_increase(mi_get_default_heap()->tld->stats.threads, 1);
 
   // set hooks so our mi_thread_done() will be called
   #if defined(_WIN32) && defined(MI_SHARED_LIB)
@@ -354,7 +354,7 @@ void mi_thread_done(void) mi_attr_noexcept {
   // stats
   mi_heap_t* heap = mi_get_default_heap();
   if (!_mi_is_main_thread() && mi_heap_is_initialized(heap))  {
-    _mi_stat_decrease(&heap->tld->stats.threads, 1);
+    mi_stat_decrease(heap->tld->stats.threads, 1);
   }
 
   // abandon the thread local heap

--- a/src/page.c
+++ b/src/page.c
@@ -472,7 +472,7 @@ static void mi_page_free_list_extend( mi_heap_t* heap, mi_page_t* page, size_t e
   }
   // enable the new free list
   page->capacity += (uint16_t)extend;
-  _mi_stat_increase(&stats->page_committed, extend * page->block_size);
+  mi_stat_increase(stats->page_committed, extend * page->block_size);
 }
 
 /* -----------------------------------------------------------
@@ -501,7 +501,7 @@ static void mi_page_extend_free(mi_heap_t* heap, mi_page_t* page, mi_stats_t* st
 
   size_t page_size;
   _mi_page_start(_mi_page_segment(page), page, &page_size);  
-  _mi_stat_increase(&stats->pages_extended, 1);
+  mi_stat_increase(stats->pages_extended, 1);
 
   // calculate the extend count
   size_t extend = page->reserved - page->capacity;
@@ -607,7 +607,7 @@ static mi_page_t* mi_page_queue_find_free_ex(mi_heap_t* heap, mi_page_queue_t* p
     page = next;
   } // for each page
 
-  _mi_stat_counter_increase(&heap->tld->stats.searches,count);
+  mi_stat_counter_increase(heap->tld->stats.searches,count);
 
   if (page == NULL) {
     page = rpage;

--- a/src/stats.c
+++ b/src/stats.c
@@ -28,6 +28,7 @@ void _mi_stats_done(mi_stats_t* stats) {
   Statistics operations
 ----------------------------------------------------------- */
 
+#if MI_STAT>0
 static void mi_stat_update(mi_stat_count_t* stat, int64_t amount) {
   if (amount == 0) return;
   bool in_main = ((uint8_t*)stat >= (uint8_t*)&_mi_stats_main
@@ -62,7 +63,6 @@ void _mi_stat_counter_increase(mi_stat_counter_t* stat, size_t amount) {
   mi_atomic_add( &stat->total, (int64_t)amount );
 }
 
-
 void _mi_stat_increase(mi_stat_count_t* stat, size_t amount) {
   mi_stat_update(stat, (int64_t)amount);
 }
@@ -70,6 +70,7 @@ void _mi_stat_increase(mi_stat_count_t* stat, size_t amount) {
 void _mi_stat_decrease(mi_stat_count_t* stat, size_t amount) {
   mi_stat_update(stat, -((int64_t)amount));
 }
+#endif /* MI_STAT>0 */
 
 // must be thread safe as it is called from stats_merge
 static void mi_stat_add(mi_stat_count_t* stat, const mi_stat_count_t* src, int64_t unit) {


### PR DESCRIPTION
Statistics wrapper macros, mi_stat_{increase,counter_increase} are
defined as no-op when MI_STAT equals to 0 (no runtime statistics).
However, even MI_STAT is set to 0, internal functions such as
_mi_stat_increase are invoked unexpectedly. This patch enforces the use
of mi_stat wrapper macros and MI_STAT.