### PR TITLE
Add branch prediction hint for mi_option_get

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -51,7 +51,7 @@ static void mi_option_init(mi_option_desc_t* desc);
 long mi_option_get(mi_option_t option) {
   mi_assert(option >= 0 && option < _mi_option_last);
   mi_option_desc_t* desc = &options[option];
-  if (desc->init == UNINIT) {
+  if (mi_unlikely(desc->init == UNINIT)) {
     mi_option_init(desc);
     if (option != mi_option_verbose) {
       _mi_verbose_message("option '%s': %ld\n", desc->name, desc->value);


### PR DESCRIPTION
mi_option_get is called frequently in stress tests, and the patch adds
extra hint to the compiler to emit instructions that will cause branch
prediction to favour the "likely" side of a jump instruction.