### PR TITLE
Enforce strict include-what-you-use policy

### DIFF
--- a/include/mimalloc-types.h
+++ b/include/mimalloc-types.h
@@ -8,7 +8,6 @@ terms of the MIT license. A copy of the license can be found in the file
 #ifndef MIMALLOC_TYPES_H
 #define MIMALLOC_TYPES_H
 
-#include <stdlib.h>   // size_t etc.
 #include <stddef.h>   // ptrdiff_t
 #include <stdint.h>   // uintptr_t, uint16_t, etc
 

--- a/include/mimalloc.h
+++ b/include/mimalloc.h
@@ -69,7 +69,6 @@ terms of the MIT license. A copy of the license can be found in the file
 // Includes
 // ------------------------------------------------------
 
-#include <stdlib.h>     // size_t, malloc etc.
 #include <stdbool.h>    // bool
 #include <stdio.h>      // FILE
 

--- a/src/alloc-aligned.c
+++ b/src/alloc-aligned.c
@@ -8,7 +8,7 @@ terms of the MIT license. A copy of the license can be found in the file
 #include "mimalloc.h"
 #include "mimalloc-internal.h"
 
-#include <string.h>  // memset
+#include <string.h>  // memset, memcpy
 
 // ------------------------------------------------------
 // Aligned Allocation

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -8,7 +8,8 @@ terms of the MIT license. A copy of the license can be found in the file
 #include "mimalloc-internal.h"
 #include "mimalloc-atomic.h"
 
-#include <string.h>  // memset
+#include <string.h>  // memset, memcpy, strlen
+#include <stdlib.h>  // malloc, exit
 
 #define MI_IN_ALLOC_C
 #include "alloc-override.c"
@@ -463,7 +464,7 @@ char* mi_heap_realpath(mi_heap_t* heap, const char* fname, char* resolved_name) 
   }
 }
 #else
-#include <unistd.h>
+#include <unistd.h>  // pathconf
 static size_t mi_path_max() {
   static size_t path_max = 0;
   if (path_max <= 0) {

--- a/src/init.c
+++ b/src/init.c
@@ -7,7 +7,8 @@ terms of the MIT license. A copy of the license can be found in the file
 #include "mimalloc.h"
 #include "mimalloc-internal.h"
 
-#include <string.h>  // memcpy
+#include <string.h>  // memcpy, memset
+#include <stdlib.h>  // atexit
 
 // Empty page used to initialize the small free pages array
 const mi_page_t _mi_page_empty = {

--- a/src/options.c
+++ b/src/options.c
@@ -8,7 +8,8 @@ terms of the MIT license. A copy of the license can be found in the file
 #include "mimalloc-internal.h"
 
 #include <stdio.h>
-#include <string.h> // strcmp
+#include <stdlib.h> // strtol
+#include <string.h> // strncpy, strncat, strlen, strstr
 #include <ctype.h>  // toupper
 #include <stdarg.h>
 

--- a/src/os.c
+++ b/src/os.c
@@ -11,7 +11,7 @@ terms of the MIT license. A copy of the license can be found in the file
 #include "mimalloc.h"
 #include "mimalloc-internal.h"
 
-#include <string.h>  // memset
+#include <string.h>  // strerror
 #include <errno.h>
 
 #if defined(_WIN32)

--- a/src/page.c
+++ b/src/page.c
@@ -15,8 +15,6 @@ terms of the MIT license. A copy of the license can be found in the file
 #include "mimalloc-internal.h"
 #include "mimalloc-atomic.h"
 
-#include <string.h>  // memset, memcpy
-
 /* -----------------------------------------------------------
   Definition of page queues for each block size
 ----------------------------------------------------------- */


### PR DESCRIPTION
The include-what-you-use (IWYU) policy is beneficial to faster
compilation and fewer recompilations. Many build tools, such as GNU make,
provide a mechanism for automatically figuring out what .h files a .cc
file depends on. These mechanisms typically look at #include lines. When
unnecessary #includes are listed, the build system is more likely to
recompile in cases where it is not necessary.

With the enforcement, header file <include/mimalloc.h> no longer
includes <stdlib.h>.

Reference:
https://github.com/include-what-you-use/include-what-you-use/blob/master/docs/WhyIWYU.md