### PR TITLE
Replace power of 2 checks with inline functions

### DIFF
--- a/include/mimalloc-internal.h
+++ b/include/mimalloc-internal.h
@@ -170,7 +170,7 @@ static inline uintptr_t _mi_is_power_of_two(uintptr_t x) {
 }
 static inline uintptr_t _mi_align_up(uintptr_t sz, size_t alignment) {
   uintptr_t mask = alignment - 1;
-  if ((alignment & mask) == 0) {  // power of two?
+  if (_mi_is_power_of_two(alignment)) {
     return ((sz + mask) & ~mask);
   }
   else {

--- a/src/alloc-posix.c
+++ b/src/alloc-posix.c
@@ -46,7 +46,7 @@ int mi_posix_memalign(void** p, size_t alignment, size_t size) mi_attr_noexcept 
   // <http://man7.org/linux/man-pages/man3/posix_memalign.3.html>
   if (p == NULL) return EINVAL;
   if (alignment % sizeof(void*) != 0) return EINVAL;      // natural alignment
-  if ((alignment & (alignment - 1)) != 0) return EINVAL;  // not a power of 2
+  if ((_mi_is_power_of_two(alignment) != 0)) return EINVAL;
   void* q = mi_malloc_aligned(size, alignment);
   if (q==NULL && size != 0) return ENOMEM;
   *p = q;


### PR DESCRIPTION
Replace power of 2 checks `(x & x-1 )== 0` with inline function ` _mi_is_power_of_two(x) ` making codes even easier to read.