### PR TITLE
static analysis fixes

### DIFF
--- a/src/alloc-aligned.c
+++ b/src/alloc-aligned.c
@@ -71,7 +71,7 @@ void* mi_heap_zalloc_aligned(mi_heap_t* heap, size_t size, size_t alignment) mi_
 
 void* mi_heap_calloc_aligned_at(mi_heap_t* heap, size_t count, size_t size, size_t alignment, size_t offset) mi_attr_noexcept {
   size_t total;
-  if (mi_mul_overflow(count, size, &total)) return NULL;
+  if (mi_mul_overflow(size, count, &total)) return NULL;
   return mi_heap_zalloc_aligned_at(heap, total, alignment, offset);
 }
 

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -322,7 +322,7 @@ void mi_free_aligned(void* p, size_t alignment) mi_attr_noexcept {
 
 extern inline void* mi_heap_calloc(mi_heap_t* heap, size_t count, size_t size) mi_attr_noexcept {
   size_t total;
-  if (mi_mul_overflow(count,size,&total)) return NULL;
+  if (mi_mul_overflow(size,count,&total)) return NULL;
   return mi_heap_zalloc(heap,total);
 }
 
@@ -333,7 +333,7 @@ void* mi_calloc(size_t count, size_t size) mi_attr_noexcept {
 // Uninitialized `calloc`
 extern void* mi_heap_mallocn(mi_heap_t* heap, size_t count, size_t size) mi_attr_noexcept {
   size_t total;
-  if (mi_mul_overflow(count,size,&total)) return NULL;
+  if (mi_mul_overflow(size,count,&total)) return NULL;
   return mi_heap_malloc(heap, total);
 }
 
@@ -374,7 +374,7 @@ void* mi_heap_realloc(mi_heap_t* heap, void* p, size_t newsize) mi_attr_noexcept
 
 void* mi_heap_reallocn(mi_heap_t* heap, void* p, size_t count, size_t size) mi_attr_noexcept {
   size_t total;
-  if (mi_mul_overflow(count, size, &total)) return NULL;
+  if (mi_mul_overflow(size, count, &total)) return NULL;
   return mi_heap_realloc(heap, p, total);
 }
 
@@ -392,7 +392,7 @@ void* mi_realloc(void* p, size_t newsize) mi_attr_noexcept {
 
 void* mi_recalloc(void* p, size_t count, size_t size) mi_attr_noexcept {
   size_t total;
-  if (mi_mul_overflow(count, size, &total)) return NULL;
+  if (mi_mul_overflow(size, count, &total)) return NULL;
   return _mi_heap_realloc_zero(mi_get_default_heap(),p,total,true);
 }
 

--- a/src/page.c
+++ b/src/page.c
@@ -142,7 +142,7 @@ static void mi_page_thread_free_collect(mi_page_t* page)
   mi_thread_free_t tfree;
   mi_thread_free_t tfreex;
   do {
-    tfreex = tfree = page->thread_free;
+    tfree = page->thread_free;
     head = mi_tf_block(tfree);
     tfreex = mi_tf_set_block(tfree,NULL);
   } while (!mi_atomic_compare_exchange((volatile uintptr_t*)&page->thread_free, tfreex, tfree));


### PR DESCRIPTION
There is a useless assignment in page.c, and the rest are bad parameter order for calls to mi_mul_overflow