### PR TITLE
Fix C++ signature of function mi_is_in_heap_region

### DIFF
--- a/src/memory.c
+++ b/src/memory.c
@@ -105,7 +105,7 @@ static size_t mi_good_commit_size(size_t size) {
 }
 
 // Return if a pointer points into a region reserved by us.
-bool mi_is_in_heap_region(const void* p) {
+bool mi_is_in_heap_region(const void* p) mi_attr_noexcept {
   size_t count = mi_atomic_read(&regions_count);
   for (size_t i = 0; i < count; i++) {
     uint8_t* start = (uint8_t*)mi_atomic_read_ptr(&regions[i].start);


### PR DESCRIPTION
Original code did not compile with MI_USE_CXX=ON as function
mi_is_in_heap_region was declared noexcept through macro mi_attr_noexcept
but defined without specification, i.e. implicitly with noexception(false)

Just adding the macro in the definition is enough to fix the issue
(tested with gcc 8.3.5)