### PR TITLE
Link with -lrt for older glibc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,10 @@ if(WIN32)
   list(APPEND mi_libraries psapi shell32 user32)
 else()
   list(APPEND mi_libraries pthread)
+  find_library(LIBRT rt)
+  if(LIBRT)
+    list(APPEND mi_libraries ${LIBRT})
+  endif()
 endif()
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Quoted from Linux Programmer's Manual (2017-09-15):
    #include <time.h>
    int clock_gettime(clockid_t clk_id, struct timespec *tp);
    Link with -lrt (only for glibc versions before 2.17).

This patch adds additional checks for librt availability and append
target_link_libraries accordingly. librt is absent on macOS.

Fixed #139