### PR TITLE
Replicate the value of _mi_default_heap in mi_pthread_key and mi_fls_key

### DIFF
--- a/include/mimalloc-internal.h
+++ b/include/mimalloc-internal.h
@@ -105,6 +105,7 @@ void        _mi_block_zero_init(const mi_page_t* page, void* p, size_t size);
 
 #if MI_DEBUG>1
 bool        _mi_page_is_valid(mi_page_t* page);
+bool        _mi_heap_is_valid(mi_heap_t* heap);
 #endif
 
 

--- a/src/heap.c
+++ b/src/heap.c
@@ -57,7 +57,7 @@ static bool _mi_heap_page_is_valid(mi_heap_t* heap, mi_page_queue_t* pq, mi_page
   return true;
 }
 
-static bool mi_heap_is_valid(mi_heap_t* heap) {
+bool _mi_heap_is_valid(mi_heap_t* heap) {
   mi_assert_internal(heap!=NULL);
   mi_heap_visit_pages(heap, &_mi_heap_page_is_valid, NULL, NULL);
   return true;
@@ -278,7 +278,7 @@ void _mi_heap_destroy_pages(mi_heap_t* heap) {
 void mi_heap_destroy(mi_heap_t* heap) {
   mi_assert(mi_heap_is_initialized(heap));
   mi_assert(heap->no_reclaim);
-  mi_assert_expensive(mi_heap_is_valid(heap));
+  mi_assert_expensive(_mi_heap_is_valid(heap));
   if (!mi_heap_is_initialized(heap)) return;
   if (!heap->no_reclaim) {
     // don't free in case it may contain reclaimed pages
@@ -335,7 +335,7 @@ static void mi_heap_absorb(mi_heap_t* heap, mi_heap_t* from) {
 void mi_heap_delete(mi_heap_t* heap)
 {
   mi_assert(mi_heap_is_initialized(heap));
-  mi_assert_expensive(mi_heap_is_valid(heap));
+  mi_assert_expensive(_mi_heap_is_valid(heap));
   if (!mi_heap_is_initialized(heap)) return;
 
   if (!mi_heap_is_backing(heap)) {

--- a/src/heap.c
+++ b/src/heap.c
@@ -223,7 +223,7 @@ static void mi_heap_free(mi_heap_t* heap) {
   
   // reset default
   if (mi_heap_is_default(heap)) {
-    _mi_heap_default = heap->tld->heap_backing;
+    mi_heap_set_default(heap->tld->heap_backing);
   }
   // and free the used memory
   mi_free(heap);
@@ -349,16 +349,6 @@ void mi_heap_delete(mi_heap_t* heap)
   mi_assert_internal(heap->page_count==0);
   mi_heap_free(heap);
 }
-
-mi_heap_t* mi_heap_set_default(mi_heap_t* heap) {
-  mi_assert(mi_heap_is_initialized(heap));
-  if (!mi_heap_is_initialized(heap)) return NULL;
-  mi_assert_expensive(mi_heap_is_valid(heap));
-  mi_heap_t* old   = _mi_heap_default;
-  _mi_heap_default = heap;
-  return old;
-}
-
 
 
 

--- a/src/init.c
+++ b/src/init.c
@@ -314,7 +314,7 @@ static void _mi_thread_done(mi_heap_t* heap) mi_attr_noexcept;
 mi_heap_t* mi_heap_set_default(mi_heap_t* heap) {
   mi_assert(mi_heap_is_initialized(heap));
   if (!mi_heap_is_initialized(heap)) return NULL;
-  mi_assert_expensive(mi_heap_is_valid(heap));
+  mi_assert_expensive(_mi_heap_is_valid(heap));
   mi_heap_t* old   = _mi_heap_default;
   _mi_heap_default = heap;
 


### PR DESCRIPTION
This is "lightly tested" (and only on Mac OS).

```
On Mac OS, the thread-local _mi_default_heap may get reset before
_mi_thread_done is called, leaking the default heap on non-main threads.

Now the current default heap is also stored in mi_pthread_key (or mi_fls_key
on Windows). The _mi_thread_done function is called with this value.

See #164
```