### PR TITLE
Updated install location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ option(MI_SECURE            "Use security mitigations (like guard pages and rand
 option(MI_LOCAL_DYNAMIC_TLS "Use slightly slower, dlopen-compatible TLS mechanism (Unix)" OFF)
 option(MI_BUILD_TESTS       "Build test executables" ON)
 
-set(mi_install_dir "lib/mimalloc-${mi_version}")
+set(mi_install_dir "${CMAKE_INSTALL_PREFIX}/lib/mimalloc-${mi_version}")
 
 set(mi_sources
     src/stats.c


### PR DESCRIPTION
Further to #167 , prefix ${CMAKE_INSTALL_PREFIX} to the install directory. Note: Untested on anything other than Linux.