### PR TITLE
Avoid the use of variable argument list function

### DIFF
--- a/include/mimalloc-atomic.h
+++ b/include/mimalloc-atomic.h
@@ -220,7 +220,7 @@ static inline void mi_atomic_write(volatile _Atomic(uintptr_t)* p, uintptr_t x) 
 #endif
 #elif defined(__wasi__)
   #include <sched.h>
-  static inline void mi_atomic_yield() {
+  static inline void mi_atomic_yield(void) {
     sched_yield();
   }
 #else


### PR DESCRIPTION
Changed `mi_atomic_yield();` to `mi_atomic_yield(void);` in order to match its function prototype.