### PR TITLE
Tweaks to mi_stl_allocator, and mark a few functions as nodiscard if >=C++20

### DIFF
--- a/include/mimalloc-new-delete.h
+++ b/include/mimalloc-new-delete.h
@@ -25,11 +25,11 @@ terms of the MIT license. A copy of the license can be found in the file
   void operator delete(void* p) noexcept              { mi_free(p); };
   void operator delete[](void* p) noexcept            { mi_free(p); };
 
-  void* operator new(std::size_t n) noexcept(false)   { return mi_new(n); }
-  void* operator new[](std::size_t n) noexcept(false) { return mi_new(n); }
+  mi_attr_nodiscard_if_cpp20 void* operator new(std::size_t n) noexcept(false)   { return mi_new(n); }
+  mi_attr_nodiscard_if_cpp20 void* operator new[](std::size_t n) noexcept(false) { return mi_new(n); }
 
-  void* operator new  (std::size_t n, const std::nothrow_t& tag) noexcept { (void)(tag); return mi_new_nothrow(n); }
-  void* operator new[](std::size_t n, const std::nothrow_t& tag) noexcept { (void)(tag); return mi_new_nothrow(n); }
+  mi_attr_nodiscard_if_cpp20 void* operator new  (std::size_t n, const std::nothrow_t& tag) noexcept { (void)(tag); return mi_new_nothrow(n); }
+  mi_attr_nodiscard_if_cpp20 void* operator new[](std::size_t n, const std::nothrow_t& tag) noexcept { (void)(tag); return mi_new_nothrow(n); }
 
   #if (__cplusplus >= 201402L || _MSC_VER >= 1916)
   void operator delete  (void* p, std::size_t n) { mi_free_size(p,n); };
@@ -42,10 +42,10 @@ terms of the MIT license. A copy of the license can be found in the file
   void operator delete  (void* p, std::size_t n, std::align_val_t al) noexcept { mi_free_size_aligned(p, n, static_cast<size_t>(al)); };
   void operator delete[](void* p, std::size_t n, std::align_val_t al) noexcept { mi_free_size_aligned(p, n, static_cast<size_t>(al)); };
 
-  void* operator new( std::size_t n, std::align_val_t al)   noexcept(false) { return mi_new_aligned(n, static_cast<size_t>(al)); }
-  void* operator new[]( std::size_t n, std::align_val_t al) noexcept(false) { return mi_new_aligned(n, static_cast<size_t>(al)); }
-  void* operator new  (std::size_t n, std::align_val_t al, const std::nothrow_t&) noexcept { return mi_new_aligned_nothrow(n, static_cast<size_t>(al)); }
-  void* operator new[](std::size_t n, std::align_val_t al, const std::nothrow_t&) noexcept { return mi_new_aligned_nothrow(n, static_cast<size_t>(al)); }
+  mi_attr_nodiscard_if_cpp20 void* operator new( std::size_t n, std::align_val_t al)   noexcept(false) { return mi_new_aligned(n, static_cast<size_t>(al)); }
+  mi_attr_nodiscard_if_cpp20 void* operator new[]( std::size_t n, std::align_val_t al) noexcept(false) { return mi_new_aligned(n, static_cast<size_t>(al)); }
+  mi_attr_nodiscard_if_cpp20 void* operator new  (std::size_t n, std::align_val_t al, const std::nothrow_t&) noexcept { return mi_new_aligned_nothrow(n, static_cast<size_t>(al)); }
+  mi_attr_nodiscard_if_cpp20 void* operator new[](std::size_t n, std::align_val_t al, const std::nothrow_t&) noexcept { return mi_new_aligned_nothrow(n, static_cast<size_t>(al)); }
   #endif
 #endif
 

--- a/include/mimalloc.h
+++ b/include/mimalloc.h
@@ -407,7 +407,7 @@ template<class T> struct mi_stl_allocator {
   #endif
 
   size_type     max_size() const mi_attr_noexcept { return (std::numeric_limits<difference_type>::max() / sizeof(value_type)); }
-  #if (__cplusplus >= 201103L) || (_MSC_VER > 1900)) // C++11
+  #if ((__cplusplus >= 201103L) || (_MSC_VER > 1900)) // C++11
   pointer       address(reference x) const mi_attr_noexcept        { return std::addressof(x); }
   const_pointer address(const_reference x) const mi_attr_noexcept  { return std::addressof(x); }
   #else

--- a/include/mimalloc.h
+++ b/include/mimalloc.h
@@ -368,7 +368,7 @@ mi_decl_export void* mi_new_reallocn(void* p, size_t newcount, size_t size) mi_a
 #if (__cplusplus >= 201103L) || (_MSC_VER > 1900)  // C++11
 #include <type_traits> // std::true_type
 #include <utility>     // std::forward
-#include <memory> // std::addressof
+#include <memory>      // std::addressof
 #endif
 
 template<class T> struct mi_stl_allocator {
@@ -412,7 +412,7 @@ template<class T> struct mi_stl_allocator {
   const_pointer address(const_reference x) const mi_attr_noexcept  { return std::addressof(x); }
   #else
   // Oversimplified implementation as presented here: <https://en.cppreference.com/w/cpp/memory/addressof>
-  // This is also used as a fallback by libcxx, and as the sole implementation by libstdcxx, so should be good enough for us
+  // This is also used as a fallback by libcxx, and as the sole implementation by libstdc++, so should be good enough for us
   pointer       address(reference x) const mi_attr_noexcept        { return reinterpret_cast<pointer>(&const_cast<char&>(reinterpret_cast<const volatile char&>(x))); }
   const_pointer address(const_reference x) const mi_attr_noexcept  { return reinterpret_cast<const_pointer>(&const_cast<char&>(reinterpret_cast<const volatile char&>(x))); }
   #endif

--- a/include/mimalloc.h
+++ b/include/mimalloc.h
@@ -20,8 +20,14 @@ terms of the MIT license. A copy of the license can be found in the file
   #else
     #define mi_attr_noexcept   throw()
   #endif
+  #if __cplusplus > 201703L //C++20
+    #define mi_attr_nodiscard_if_cpp20 [[nodiscard]]
+  #else
+    #define mi_attr_nodiscard_if_cpp20
+  #endif
 #else
   #define mi_attr_noexcept
+  #define mi_attr_nodiscard_if_cpp20
 #endif
 
 #ifdef _MSC_VER
@@ -381,8 +387,8 @@ template<class T> struct mi_stl_allocator {
   void              deallocate(T* p, size_type) { mi_free(p); }
 
   #if (__cplusplus >= 201703L)  // C++17
-  T* allocate(size_type count) { return static_cast<T*>(mi_new_n(count, sizeof(T))); }
-  T* allocate(size_type count, const void*) { return allocate(count); }
+  mi_attr_nodiscard_if_cpp20 T* allocate(size_type count) { return static_cast<T*>(mi_new_n(count, sizeof(T))); }
+  mi_attr_nodiscard_if_cpp20 T* allocate(size_type count, const void*) { return allocate(count); }
   #else
   pointer allocate(size_type count, const void* = 0) { return static_cast<pointer>(mi_new_n(count, sizeof(value_type))); }
   #endif


### PR DESCRIPTION
This PR adds `mi_attr_nodiscard_if_cpp20`(name is selfexplanatory) on functions made `[[nodiscard]]` in C++20 and makes `mi_stl_allocator::address` work even on types that overload `operator&`