### PR TITLE
Don't call mi_page_usable_size_of with an aligned pointer

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -472,15 +472,16 @@ size_t mi_usable_size(const void* p) mi_attr_noexcept {
   if (p==NULL) return 0;
   const mi_segment_t* const segment = _mi_ptr_segment(p);
   const mi_page_t* const page = _mi_segment_page_of(segment, p);
-  const mi_block_t* const block = (const mi_block_t*)p;
-  const size_t size = mi_page_usable_size_of(page, block);
+  const mi_block_t* block = (const mi_block_t*)p;
   if (mi_unlikely(mi_page_has_aligned(page))) {
-    ptrdiff_t const adjust = (uint8_t*)p - (uint8_t*)_mi_page_ptr_unalign(segment,page,p);
+    block = _mi_page_ptr_unalign(segment, page, p);
+    size_t size = mi_page_usable_size_of(page, block);
+    ptrdiff_t const adjust = (uint8_t*)p - (uint8_t*)block;
     mi_assert_internal(adjust >= 0 && (size_t)adjust <= size);
     return (size - adjust);
   }
   else {
-    return size;
+    return mi_page_usable_size_of(page, block);
   }
 }
 

--- a/test/test-api.c
+++ b/test/test-api.c
@@ -152,6 +152,9 @@ int main() {
     }
     result = ok;
   });
+  CHECK_BODY("malloc-aligned5", {
+    void* p = mi_malloc_aligned(4097,4096); size_t usable = mi_usable_size(p); result = usable >= 4097 && usable < 10000; mi_free(p);
+  });
   CHECK_BODY("malloc-aligned-at1", {
     void* p = mi_malloc_aligned_at(48,32,0); result = (p != NULL && ((uintptr_t)(p) + 0) % 32 == 0); mi_free(p);
   });


### PR DESCRIPTION
This is a subtle one. The bug only happens with MI_SECURE, you need debug assertions enabled to see it in the test suite, and it is a bit non-deterministic, so it has to run a few times. Checkout the test without the fix and you should be able to repro the assertion failing by running `cmake -DCMAKE_BUILD_TYPE=Debug -DMI_SECURE ../.. && make -j9 && ./mimalloc-test-api` a few times.

First, you need an aligned allocation. The alignment and size have to be such that "adjust" is nonzero, i.e. the returned pointer is offset from the start of a block. An example is size=4097, align=4096.

Then, you need to call mi_usable_size() on that allocation. In that function, block is cast directly from p. Casting this is invalid with aligned pointers. mi_page_usable_size_of is then called on "block", which isn't a block.

From there, it can fail in a few ways, depending.

1. When checking the padding, the reads `*delta = padding->delta` and `padding->canary` can be well into another block. Basically each will be a long way off target, so the canary checking code will spuriously fail or spuriously succeed, and so can the delta/bsize comparison.
2. You can segfault, because of the reads in (1). I have seen it once or twice. It depends on where the segment is allocated, because of the deterministic freelist shuffling. So you could try to fill a freelist to repro reliably, but I am already certain it can happen.
3. Can fail a debug assertion `mi_assert_internal(ok)` in mi_page_usable_size_of, because of (1).
4. Without debug assertions, if the canary check fails, it manifests as a "usable size" of `0 - adjust`, i.e. nearly 2^64, because the size returned from mi_page_usable_size_of is zero to indicate failure. That is indeed meant to happen when user code overflows/the canary is overwritten. So a check + an error message is probably necessary here, though I'm not sure what the protocol would be for aborting or continuing.

So there you go. I've been having a go translating mimalloc into rust with `c2rust`, and found this while reading how usable size was computed, to implement the bleeding-edge Rust allocation APIs. It's going quite well, I'll share soon.