### PR TITLE
Fix Windows builds on Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,12 +18,15 @@ jobs:
       Debug:
         BuildType: debug
         cmakeExtraArgs: -DCMAKE_BUILD_TYPE=Debug -DMI_DEBUG_FULL=ON
+        MSBuildConfiguration: Debug
       Release:
         BuildType: release
         cmakeExtraArgs: -DCMAKE_BUILD_TYPE=Release
+        MSBuildConfiguration: Release
       Secure:
         BuildType: secure
         cmakeExtraArgs: -DCMAKE_BUILD_TYPE=Release -DMI_SECURE=ON
+        MSBuildConfiguration: Release
   steps:
   - task: CMake@1
     inputs:
@@ -32,6 +35,7 @@ jobs:
   - task: MSBuild@1
     inputs:
       solution: $(BuildType)/libmimalloc.sln
+      configuration: '$(MSBuildConfiguration)'
   - script: |
       cd $(BuildType)
       ctest


### PR DESCRIPTION
Currently, all Windows builds are using `Debug|x64` configuration. For example, you can see the CTest steps with Release build cost 20+ seconds, which means it is using the debug binary.