### PR TITLE
Add cmake option to specify whether warnings / errors are enabled by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ option(MI_LOCAL_DYNAMIC_TLS "Use slightly slower, dlopen-compatible TLS mechanis
 option(MI_BUILD_TESTS       "Build test executables" ON)
 option(MI_CHECK_FULL        "Use full internal invariant checking in DEBUG mode (deprecated, use MI_DEBUG_FULL instead)" OFF)
 option(MI_PADDING           "Enable padding to detect heap block overflow (only in debug mode)" ON)
+option(MI_SHOW_ERRORS       "Show error and warning messages by default" OFF)
 
 include("cmake/mimalloc-config-version.cmake")
 
@@ -103,6 +104,13 @@ endif()
 if(MI_PADDING MATCHES "OFF")
   message(STATUS "Disable padding of heap blocks in debug mode (MI_PADDING=OFF)")
   list(APPEND mi_defines MI_PADDING=0)
+endif()
+
+if(MI_SHOW_ERRORS MATCHES "ON")
+  message(STATUS "Enable printing of error and warning messages by default (MI_SHOW_ERRORS=ON)")
+  list(APPEND mi_defines MI_SHOW_ERRORS=1)
+else()
+  list(APPEND mi_defines MI_SHOW_ERRORS=0)
 endif()
 
 if(MI_USE_CXX MATCHES "ON")

--- a/include/mimalloc-types.h
+++ b/include/mimalloc-types.h
@@ -61,7 +61,6 @@ terms of the MIT license. A copy of the license can be found in the file
 #define MI_ENCODE_FREELIST  1
 #endif
 
-
 // ------------------------------------------------------
 // Platform specific values
 // ------------------------------------------------------

--- a/src/options.c
+++ b/src/options.c
@@ -51,7 +51,7 @@ typedef struct mi_option_desc_s {
 static mi_option_desc_t options[_mi_option_last] =
 {
   // stable options
-  { MI_DEBUG, UNINIT, MI_OPTION(show_errors) },
+  { MI_DEBUG | MI_SHOW_ERRORS, UNINIT, MI_OPTION(show_errors) },
   { 0, UNINIT, MI_OPTION(show_stats) },
   { 0, UNINIT, MI_OPTION(verbose) },
 


### PR DESCRIPTION
Currently warnings / errors are enabled by default in debug build. Otherwise they could be enabled only via environmental variable or API option call. Add possibility to specify the default during the build time. This simplifies e.g. integration of the library into bigger projects as no source changes would be required.