### PR TITLE
Provide several fixes around OS X zone overrides

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ if(MI_OVERRIDE MATCHES "ON")
       # use zone's on macOS
       message(STATUS "  Use malloc zone to override malloc (MI_OSX_ZONE=ON)")
       list(APPEND mi_sources src/alloc-override-osx.c)
+      list(APPEND mi_defines MI_OSX_ZONE=1)
       if(NOT MI_INTERPOSE MATCHES "ON")
         message(STATUS "  (enabling INTERPOSE as well since zone's require this)")
         set(MI_INTERPOSE "ON")

--- a/src/alloc-override-osx.c
+++ b/src/alloc-override-osx.c
@@ -41,8 +41,11 @@ extern malloc_zone_t* malloc_default_purgeable_zone(void) __attribute__((weak_im
 ------------------------------------------------------ */
 
 static size_t zone_size(malloc_zone_t* zone, const void* p) {
-  UNUSED(zone); UNUSED(p);
-  return 0; // as we cannot guarantee that `p` comes from us, just return 0
+  UNUSED(zone);
+  if (!mi_is_in_heap_region(p))
+    return 0; // not our pointer, bail out
+  
+  return mi_usable_size(p);
 }
 
 static void* zone_malloc(malloc_zone_t* zone, size_t size) {

--- a/src/alloc-override.c
+++ b/src/alloc-override.c
@@ -165,7 +165,7 @@ extern "C" {
 
 void   cfree(void* p)                    MI_FORWARD0(mi_free, p);
 void*  reallocf(void* p, size_t newsize) MI_FORWARD2(mi_reallocf,p,newsize);
-size_t malloc_size(void* p)              MI_FORWARD1(mi_usable_size,p);
+size_t malloc_size(const void* p)        MI_FORWARD1(mi_usable_size,p);
 #if !defined(__ANDROID__)
 size_t malloc_usable_size(void *p)       MI_FORWARD1(mi_usable_size,p);
 #else

--- a/src/static.c
+++ b/src/static.c
@@ -24,5 +24,8 @@ terms of the MIT license. A copy of the license can be found in the file
 #include "alloc.c"
 #include "alloc-aligned.c"
 #include "alloc-posix.c"
+#if MI_OSX_ZONE
+#include "alloc-override-osx.c"
+#endif
 #include "init.c"
 #include "options.c"


### PR DESCRIPTION
This series of patches fixes several glitches around OS X zone implementation:
* Signature of ``malloc_size`` is corrected
* Zone implementation is added into static object
* ``zone_size`` function is implemented, otherwise free does not know which zone to use in order to free the pointer (see ``find_registered_zone`` in https://opensource.apple.com/source/Libc/Libc-594.1.4/gen/malloc.c)