### PR TITLE
Add possibility to selectively enable / disable builing of different targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,9 @@ option(MI_LOCAL_DYNAMIC_TLS "Use slightly slower, dlopen-compatible TLS mechanis
 option(MI_BUILD_TESTS       "Build test executables" ON)
 option(MI_CHECK_FULL        "Use full internal invariant checking in DEBUG mode (deprecated, use MI_DEBUG_FULL instead)" OFF)
 option(MI_PADDING           "Enable padding to detect heap block overflow (only in debug mode)" ON)
+option(MI_BUILD_SHARED      "Build shared library" ON)
+option(MI_BUILD_STATIC      "Build static library" ON)
+option(MI_BUILD_OBJECT      "Build object" ON)
 
 include("cmake/mimalloc-config-version.cmake")
 
@@ -180,52 +183,62 @@ message(STATUS "")
 # -----------------------------------------------------------------------------
 
 # shared library
-add_library(mimalloc SHARED ${mi_sources})
-set_target_properties(mimalloc PROPERTIES VERSION ${mi_version} OUTPUT_NAME ${mi_basename} )
-target_compile_definitions(mimalloc PRIVATE ${mi_defines} MI_SHARED_LIB MI_SHARED_LIB_EXPORT)
-target_compile_options(mimalloc PRIVATE ${mi_cflags})
-target_link_libraries(mimalloc PUBLIC ${mi_libraries})
-target_include_directories(mimalloc PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:${mi_install_dir}/include>
-)
-if(WIN32)
-  # On windows copy the mimalloc redirection dll too.
-  target_link_libraries(mimalloc PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/bin/mimalloc-redirect.lib)
-  add_custom_command(TARGET mimalloc POST_BUILD
-    COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_CURRENT_SOURCE_DIR}/bin/mimalloc-redirect.dll" $<TARGET_FILE_DIR:mimalloc>
-    COMMENT "Copy mimalloc-redirect.dll to output directory")
+if(MI_BUILD_SHARED)
+  message(STATUS "Shared library will be built")
+
+  add_library(mimalloc SHARED ${mi_sources})
+  set_target_properties(mimalloc PROPERTIES VERSION ${mi_version} OUTPUT_NAME ${mi_basename} )
+  target_compile_definitions(mimalloc PRIVATE ${mi_defines} MI_SHARED_LIB MI_SHARED_LIB_EXPORT)
+  target_compile_options(mimalloc PRIVATE ${mi_cflags})
+  target_link_libraries(mimalloc PUBLIC ${mi_libraries})
+  target_include_directories(mimalloc PUBLIC
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+      $<INSTALL_INTERFACE:${mi_install_dir}/include>
+  )
+  if(WIN32)
+    # On windows copy the mimalloc redirection dll too.
+    target_link_libraries(mimalloc PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/bin/mimalloc-redirect.lib)
+    add_custom_command(TARGET mimalloc POST_BUILD
+      COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_CURRENT_SOURCE_DIR}/bin/mimalloc-redirect.dll" $<TARGET_FILE_DIR:mimalloc>
+      COMMENT "Copy mimalloc-redirect.dll to output directory")
+  endif()
+
+  install(TARGETS mimalloc EXPORT mimalloc DESTINATION ${mi_install_dir} LIBRARY)
+  install(EXPORT mimalloc DESTINATION ${mi_install_dir}/cmake)
 endif()
 
 # static library
-add_library(mimalloc-static STATIC ${mi_sources})
-target_compile_definitions(mimalloc-static PRIVATE ${mi_defines} MI_STATIC_LIB)
-target_compile_options(mimalloc-static PRIVATE ${mi_cflags})
-target_link_libraries(mimalloc-static PUBLIC ${mi_libraries})
-target_include_directories(mimalloc-static PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:${mi_install_dir}/include>
-)
-if(WIN32)
-  # When building both static and shared libraries on Windows, a static library should use a
-  # different output name to avoid the conflict with the import library of a shared one.
-  string(REPLACE "mimalloc" "mimalloc-static" mi_output_name ${mi_basename})
-  set_target_properties(mimalloc-static PROPERTIES OUTPUT_NAME ${mi_output_name})
-else()
-  set_target_properties(mimalloc-static PROPERTIES OUTPUT_NAME ${mi_basename})
+if (MI_BUILD_STATIC)
+  message(STATUS "Static library will be built")
+
+  add_library(mimalloc-static STATIC ${mi_sources})
+  target_compile_definitions(mimalloc-static PRIVATE ${mi_defines} MI_STATIC_LIB)
+  target_compile_options(mimalloc-static PRIVATE ${mi_cflags})
+  target_link_libraries(mimalloc-static PUBLIC ${mi_libraries})
+  target_include_directories(mimalloc-static PUBLIC
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+      $<INSTALL_INTERFACE:${mi_install_dir}/include>
+  )
+  if(WIN32 AND MI_BUILD_SHARED)
+    # When building both static and shared libraries on Windows, a static library should use a
+    # different output name to avoid the conflict with the import library of a shared one.
+    string(REPLACE "mimalloc" "mimalloc-static" mi_output_name ${mi_basename})
+    set_target_properties(mimalloc-static PROPERTIES OUTPUT_NAME ${mi_output_name})
+  else()
+    set_target_properties(mimalloc-static PROPERTIES OUTPUT_NAME ${mi_basename})
+  endif()
+
+  install(TARGETS mimalloc-static EXPORT mimalloc DESTINATION ${mi_install_dir})
 endif()
 
-# install static and shared library, and the include files
-install(TARGETS mimalloc EXPORT mimalloc DESTINATION ${mi_install_dir} LIBRARY)
-install(TARGETS mimalloc-static EXPORT mimalloc DESTINATION ${mi_install_dir})
+# install include files
 install(FILES include/mimalloc.h DESTINATION ${mi_install_dir}/include)
 install(FILES include/mimalloc-override.h DESTINATION ${mi_install_dir}/include)
 install(FILES include/mimalloc-new-delete.h DESTINATION ${mi_install_dir}/include)
 install(FILES cmake/mimalloc-config.cmake DESTINATION ${mi_install_dir}/cmake)
 install(FILES cmake/mimalloc-config-version.cmake DESTINATION ${mi_install_dir}/cmake)
-install(EXPORT mimalloc DESTINATION ${mi_install_dir}/cmake)
 
-if(NOT WIN32)
+if(NOT WIN32 AND MI_BUILD_SHARED)
   # install a symlink in the /usr/local/lib to the versioned library
   set(mi_symlink "${CMAKE_SHARED_MODULE_PREFIX}${mi_basename}${CMAKE_SHARED_LIBRARY_SUFFIX}")
   set(mi_soname "mimalloc-${mi_version}/${mi_symlink}.${mi_version}")
@@ -234,22 +247,26 @@ if(NOT WIN32)
 endif()
 
 # single object file for more predictable static overriding
-add_library(mimalloc-obj OBJECT src/static.c)
-target_compile_definitions(mimalloc-obj PRIVATE ${mi_defines})
-target_compile_options(mimalloc-obj PRIVATE ${mi_cflags})
-target_include_directories(mimalloc-obj PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:${mi_install_dir}/include>
-)
+if (MI_BUILD_OBJECT)
+  message(STATUS "Library object will be built")
 
-# the following seems to lead to cmake warnings/errors on some systems, disable for now :-(
-# install(TARGETS mimalloc-obj EXPORT mimalloc DESTINATION ${mi_install_dir})
+  add_library(mimalloc-obj OBJECT src/static.c)
+  target_compile_definitions(mimalloc-obj PRIVATE ${mi_defines})
+  target_compile_options(mimalloc-obj PRIVATE ${mi_cflags})
+  target_include_directories(mimalloc-obj PUBLIC
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+      $<INSTALL_INTERFACE:${mi_install_dir}/include>
+  )
 
-# the FILES expression can also be: $<TARGET_OBJECTS:mimalloc-obj>
-# but that fails cmake versions less than 3.10 so we leave it as is for now
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/mimalloc-obj.dir/src/static.c${CMAKE_C_OUTPUT_EXTENSION}
-        DESTINATION ${mi_install_dir}
-        RENAME ${mi_basename}${CMAKE_C_OUTPUT_EXTENSION} )
+  # the following seems to lead to cmake warnings/errors on some systems, disable for now :-(
+  # install(TARGETS mimalloc-obj EXPORT mimalloc DESTINATION ${mi_install_dir})
+
+  # the FILES expression can also be: $<TARGET_OBJECTS:mimalloc-obj>
+  # but that fails cmake versions less than 3.10 so we leave it as is for now
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/mimalloc-obj.dir/src/static.c${CMAKE_C_OUTPUT_EXTENSION}
+         DESTINATION ${mi_install_dir}
+          RENAME ${mi_basename}${CMAKE_C_OUTPUT_EXTENSION} )
+endif()
 
 # -----------------------------------------------------------------------------
 # API surface testing
@@ -277,10 +294,16 @@ endif()
 # Set override properties
 # -----------------------------------------------------------------------------
 if (MI_OVERRIDE MATCHES "ON")
-  target_compile_definitions(mimalloc PRIVATE MI_MALLOC_OVERRIDE)
+  if (MI_BUILD_SHARED)
+    target_compile_definitions(mimalloc PRIVATE MI_MALLOC_OVERRIDE)
+  endif()
   if(NOT WIN32)
     # It is only possible to override malloc on Windows when building as a DLL.
-    target_compile_definitions(mimalloc-static PRIVATE MI_MALLOC_OVERRIDE)
-    target_compile_definitions(mimalloc-obj PRIVATE MI_MALLOC_OVERRIDE)
+    if (MI_BUILD_STATIC)
+      target_compile_definitions(mimalloc-static PRIVATE MI_MALLOC_OVERRIDE)
+    endif()
+    if (MI_BUILD_OBJECT)
+      target_compile_definitions(mimalloc-obj PRIVATE MI_MALLOC_OVERRIDE)
+    endif()
   endif()
 endif()


### PR DESCRIPTION
This would allow one to enable building of object or static library if mimalloc is integrated as a vendor component as a part of larger build system.