### PR TITLE
Fix override condition for sized dealloc with gcc 6

### DIFF
--- a/src/alloc-override.c
+++ b/src/alloc-override.c
@@ -103,7 +103,7 @@ terms of the MIT license. A copy of the license can be found in the file
   void operator delete[](void* p, std::size_t n) noexcept MI_FORWARD02(mi_free_size,p,n);
   #endif
 
-  #if (__cplusplus > 201402L || defined(__cpp_aligned_new)) && (!defined(__GNUC__) || (__GNUC__ > 5))
+  #if (__cplusplus > 201402L && defined(__cpp_aligned_new)) && (!defined(__GNUC__) || (__GNUC__ > 5))
   void operator delete  (void* p, std::align_val_t al) noexcept { mi_free_aligned(p, static_cast<size_t>(al)); }
   void operator delete[](void* p, std::align_val_t al) noexcept { mi_free_aligned(p, static_cast<size_t>(al)); }
   void operator delete  (void* p, std::size_t n, std::align_val_t al) noexcept { mi_free_size_aligned(p, n, static_cast<size_t>(al)); };


### PR DESCRIPTION
Apparently gcc 6 defines __cpp_aligned_new in C++14 mode, however no std::align_val_t is available there for obvious reasons.