### PR TITLE
In OOM case try to force collect memory and retry the allocation

### DIFF
--- a/src/page.c
+++ b/src/page.c
@@ -790,6 +790,24 @@ static mi_page_t* mi_huge_page_alloc(mi_heap_t* heap, size_t size) {
 }
 
 
+static mi_page_t *_mi_find_page(mi_heap_t* heap, size_t size) mi_attr_noexcept {
+  // huge allocation?
+  const size_t req_size = size - MI_PADDING_SIZE;  // correct for padding_size in case of an overflow on `size`  
+  if (mi_unlikely(req_size > (MI_LARGE_OBJ_SIZE_MAX - MI_PADDING_SIZE) )) {
+    if (mi_unlikely(req_size > PTRDIFF_MAX)) {  // we don't allocate more than PTRDIFF_MAX (see <https://sourceware.org/ml/libc-announce/2019/msg00001.html>)
+      _mi_error_message(EOVERFLOW, "allocation request is too large (%zu b requested)\n", req_size);
+      return NULL;
+    }
+    else {
+      return mi_huge_page_alloc(heap,size);
+    }
+  }
+
+  // otherwise find a page with free blocks in our size segregated queues
+  mi_assert_internal(size >= MI_PADDING_SIZE);
+  return mi_find_free_page(heap,size);
+}
+
 // Generic allocation routine if the fast path (`alloc.c:mi_page_malloc`) does not succeed.
 // Note: in debug mode the size includes MI_PADDING_SIZE and might have overflowed.
 void* _mi_malloc_generic(mi_heap_t* heap, size_t size) mi_attr_noexcept
@@ -809,23 +827,12 @@ void* _mi_malloc_generic(mi_heap_t* heap, size_t size) mi_attr_noexcept
   // free delayed frees from other threads
   _mi_heap_delayed_free(heap);
 
-  // huge allocation?
-  mi_page_t* page;
-  const size_t req_size = size - MI_PADDING_SIZE;  // correct for padding_size in case of an overflow on `size`  
-  if (mi_unlikely(req_size > (MI_LARGE_OBJ_SIZE_MAX - MI_PADDING_SIZE) )) {
-    if (mi_unlikely(req_size > PTRDIFF_MAX)) {  // we don't allocate more than PTRDIFF_MAX (see <https://sourceware.org/ml/libc-announce/2019/msg00001.html>)
-      _mi_error_message(EOVERFLOW, "allocation request is too large (%zu b requested)\n", req_size);
-      return NULL;
-    }
-    else {
-      page = mi_huge_page_alloc(heap,size);
-    }
+  mi_page_t* page = _mi_find_page(heap, size);
+  if (mi_unlikely(page == NULL)) { // out of memory, try to collect and retry allocation
+    mi_heap_collect(heap, true /* force */);
+    page = _mi_find_page(heap, size);
   }
-  else {
-    // otherwise find a page with free blocks in our size segregated queues
-    mi_assert_internal(size >= MI_PADDING_SIZE);
-    page = mi_find_free_page(heap,size);
-  }
+
   if (mi_unlikely(page == NULL)) { // out of memory
     _mi_error_message(ENOMEM, "cannot allocate memory (%zu bytes requested)\n", size);
     return NULL;


### PR DESCRIPTION
Could be triggered by specifying tight ulimit and some allocation workloads (e.g. doing bunch of realloc() in one thread and freeing in another).