### PR TITLE
fix: avoid warning

### DIFF
--- a/src/os.c
+++ b/src/os.c
@@ -1036,7 +1036,7 @@ static size_t mi_os_numa_nodex() {
 static size_t mi_os_numa_node_countx(void) {
   ULONG numa_max = 0;
   GetNumaHighestNodeNumber(&numa_max);
-  return (numa_max + 1);
+  return ((size_t)numa_max + 1);
 }
 #elif defined(__linux__)
 #include <sys/syscall.h>  // getcpu


### PR DESCRIPTION
VS2019 code analysis gives following warning:
warning C26451: Arithmetic overflow: Using operator '+' on a 4 byte value and then casting the result to a 8 byte value. Cast the value to the wider type before calling operator '+' to avoid overflow (io.2).