### PR TITLE
Adding conditional _DEFAULT_SOURCE definition

### DIFF
--- a/src/static.c
+++ b/src/static.c
@@ -4,7 +4,9 @@ This is free software; you can redistribute it and/or modify it under the
 terms of the MIT license. A copy of the license can be found in the file
 "LICENSE" at the root of this distribution.
 -----------------------------------------------------------------------------*/
+#ifndef _DEFAULT_SOURCE
 #define _DEFAULT_SOURCE
+#endif
 
 #include "mimalloc.h"
 #include "mimalloc-internal.h"


### PR DESCRIPTION
In order to avoid `_DEFAULT_SOURCE` redefinition warnings, I've wrapped the define statement with an `ifndef`.