### PR TITLE
include/mimalloc.h: build cleanly with more compile-time checks

### DIFF
--- a/include/mimalloc.h
+++ b/include/mimalloc.h
@@ -24,7 +24,7 @@ terms of the MIT license. A copy of the license can be found in the file
   #define mi_attr_noexcept
 #endif
 
-#if (__cplusplus >= 201703)
+#if defined(__cplusplus) && (__cplusplus >= 201703)
   #define mi_decl_nodiscard    [[nodiscard]]
 #elif (__GNUC__ >= 4) || defined(__clang__)  // includes clang, icc, and clang-cl
   #define mi_decl_nodiscard    __attribute__((warn_unused_result))
@@ -256,7 +256,7 @@ mi_decl_export bool mi_heap_visit_blocks(const mi_heap_t* heap, bool visit_all_b
 
 // Experimental
 mi_decl_nodiscard mi_decl_export bool mi_is_in_heap_region(const void* p) mi_attr_noexcept;
-mi_decl_nodiscard mi_decl_export bool mi_is_redirected() mi_attr_noexcept;
+mi_decl_nodiscard mi_decl_export bool mi_is_redirected(void) mi_attr_noexcept;
 
 mi_decl_export int mi_reserve_huge_os_pages_interleave(size_t pages, size_t numa_nodes, size_t timeout_msecs) mi_attr_noexcept;
 mi_decl_export int mi_reserve_huge_os_pages_at(size_t pages, int numa_node, size_t timeout_msecs) mi_attr_noexcept;


### PR DESCRIPTION
1. check whether `__cplusplus` is defined before checking for C++17
   when defining `mi_decl_nodiscard`.  Flagged by `gcc -Wundef`.

2. give `mi_is_redirected` a full prototype in C: an empty argument
   list leave it undefined.  Flagged by `gcc -Wstrict-prototypes`.