### PR TITLE
Fix rare access violation on out of memory

### DIFF
--- a/src/region.c
+++ b/src/region.c
@@ -297,9 +297,13 @@ static void* mi_region_try_alloc(size_t blocks, bool* commit, bool* is_large, bo
     mi_bitmap_claim(&region->commit, 1, blocks, bit_idx, &any_uncommitted);
     if (any_uncommitted) {
       mi_assert_internal(!info.x.is_large);
-      bool commit_zero;
-      _mi_mem_commit(p, blocks * MI_SEGMENT_SIZE, &commit_zero, tld);
+      bool commit_zero = false;
+      bool ok = _mi_mem_commit(p, blocks * MI_SEGMENT_SIZE, &commit_zero, tld);
       if (commit_zero) *is_zero = true;
+      if (!ok)
+      {
+        return NULL;
+      }
     }
   }
   else {

--- a/src/segment.c
+++ b/src/segment.c
@@ -208,7 +208,11 @@ static void mi_segment_protect(mi_segment_t* segment, bool protect, mi_os_tld_t*
       uint8_t* start = (uint8_t*)segment + segment->segment_size - os_psize;
       if (protect && !segment->mem_is_committed) {
         // ensure secure page is committed
+#if (MI_DEBUG>1)
+        bool ok =
+#endif
         _mi_mem_commit(start, os_psize, NULL, tld);
+        mi_assert_internal(ok);
       }
       mi_segment_protect_range(start, os_psize, protect);
     }
@@ -606,8 +610,11 @@ static mi_segment_t* mi_segment_init(mi_segment_t* segment, size_t required, mi_
       // ensure the initial info is committed
       if (segment->capacity < capacity) {
         bool commit_zero = false;
-        _mi_mem_commit(segment, pre_size, &commit_zero, tld->os);
+        bool ok = _mi_mem_commit(segment, pre_size, &commit_zero, tld->os);
         if (commit_zero) is_zero = true;
+        if (!ok) {
+          return NULL;
+        }
       }
     }
   }


### PR DESCRIPTION
I don't have small example which reproduce access violation, but I had access violation in one project which is able to recover from std::bad_alloc with standard allocators and with tcmalloc, but was crashing with mimalloc (using vs2015 and vs2019).

Only `region.c` change was needed to fix a crash, but I've added code in other cases when `_mi_mem_commit` result was ignored just in case. I don't know enough about mimalloc, maybe some additional deinitialization is needed, but at least my crash is gone with such fix.

I've only tested this fix with mimalloc 1.6.4 and not with dev branch, but i see that other PRs created vs dev branch, so I've did the same.