### PR TITLE
fix for x32 builds

### DIFF
--- a/include/mimalloc-internal.h
+++ b/include/mimalloc-internal.h
@@ -699,6 +699,8 @@ static inline void* mi_tls_slot(size_t slot) mi_attr_noexcept {
   __asm__("movl %%gs:%1, %0" : "=r" (res) : "m" (*((void**)ofs)) : );  // 32-bit always uses GS
 #elif defined(__MACH__) && defined(__x86_64__)
   __asm__("movq %%gs:%1, %0" : "=r" (res) : "m" (*((void**)ofs)) : );  // x86_64 macOSX uses GS
+#elif defined(__x86_64__) && (MI_INTPTR_SIZE==4)
+  __asm__("movl %%fs:%1, %0" : "=r" (res) : "m" (*((void**)ofs)) : );  // x32 ABI
 #elif defined(__x86_64__)
   __asm__("movq %%fs:%1, %0" : "=r" (res) : "m" (*((void**)ofs)) : );  // x86_64 Linux, BSD uses FS
 #elif defined(__arm__)
@@ -720,6 +722,8 @@ static inline void mi_tls_slot_set(size_t slot, void* value) mi_attr_noexcept {
   __asm__("movl %1,%%gs:%0" : "=m" (*((void**)ofs)) : "rn" (value) : );  // 32-bit always uses GS
 #elif defined(__MACH__) && defined(__x86_64__)
   __asm__("movq %1,%%gs:%0" : "=m" (*((void**)ofs)) : "rn" (value) : );  // x86_64 macOSX uses GS
+#elif defined(__x86_64__) && (MI_INTPTR_SIZE==4)
+  __asm__("movl %1,%%fs:%1" : "=m" (*((void**)ofs)) : "rn" (value) : );  // x32 ABI
 #elif defined(__x86_64__)
   __asm__("movq %1,%%fs:%1" : "=m" (*((void**)ofs)) : "rn" (value) : );  // x86_64 Linux, BSD uses FS
 #elif defined(__arm__)


### PR DESCRIPTION
Now mimalloc builds on x32, one test fails though.

```
test: malloc-zero...  ok.
test: malloc-nomem1...  mimalloc: warning: mi_usable_size: pointer might not point to a valid heap region: 0x73400100
(this may still be a valid very large allocation (over 64MiB))
mimalloc: warning: (yes, the previous pointer 0x73400100 was valid after all)
mimalloc: warning: mi_usable_size: pointer might not point to a valid heap region: 0x73400100
(this may still be a valid very large allocation (over 64MiB))
mimalloc: warning: (yes, the previous pointer 0x73400100 was valid after all)

  FAILED: /root/src/mimalloc/test/test-api.c:85:
  { result = (mi_malloc(SIZE_MAX/2) == NULL); }
test: malloc-null...  ok.
test: calloc-overflow...  mimalloc: error: allocation request is too large (1448817038 * 4294967 bytes)
ok.
test: calloc0...  ok.
test: posix_memalign1...  ok.
test: posix_memalign_no_align...  ok.
test: posix_memalign_zero...  ok.
test: posix_memalign_nopow2...  ok.
test: posix_memalign_nomem...  mimalloc: error: allocation request is too large (4294967295 bytes)
mimalloc: error: allocation request is too large (4294967295 bytes)
mimalloc: error: unable to allocate memory (4294967295 bytes)
ok.
test: malloc-aligned1...  ok.
test: malloc-aligned2...  ok.
test: malloc-aligned3...  ok.
test: malloc-aligned4...  ok.
test: malloc-aligned5...  ok.
test: malloc-aligned-at1...  ok.
test: malloc-aligned-at2...  ok.
test: memalign1...  ok.
test: heap_destroy...  ok.
test: heap_delete...  ok.
test: realpath...  ok.
test: stl_allocator1...  ok.
test: stl_allocator2...  ok.


---------------------------------------------
succeeded: 22
failed   : 1


```
```
x210 ~/src/mimalloc/out # ./mimalloc-test-stress
Using 32 threads with a 10% load-per-thread and 50 iterations
- iterations left:  40
- iterations left:  30
- iterations left:  20
- iterations left:  10
- iterations left:   0
heap stats:     peak      total      freed       unit      count
normal   2:    19.2 mb    29.1 mb    29.1 mb       8 b      3.8 m   ok
normal   8:    38.5 mb    58.2 mb    58.2 mb      32 b      1.9 m   ok
normal  10:    57.4 mb    86.8 mb    86.8 mb      48 b      1.8 m   ok
normal  13:    95.9 mb   144.6 mb   144.6 mb      80 b      1.8 m   ok
normal  17:    75.6 mb    75.8 mb    75.8 mb     160 b    497.1 k   not all freed!
normal  21:   152.6 mb   152.6 mb   152.6 mb     320 b    500.1 k   ok
normal  23:     9.6 mb    14.1 mb    14.1 mb     448 b     33.2 k   ok
normal  27:    20.0 mb    29.4 mb    29.4 mb     896 b     34.4 k   ok
normal  29:     1.2 kb     1.2 kb       0 b      1.2 kb       1     not all freed!
normal  31:    38.9 mb    55.3 mb    55.3 mb     1.7 kb    32.4 k   ok
normal  32:   401.5 kb   401.5 kb   401.5 kb     2.0 kb     200     ok
normal  35:    73.4 mb   108.5 mb   108.5 mb     3.5 kb    31.7 k   ok
normal  36:    11.7 mb    14.8 mb    14.8 mb     4.0 kb     3.8 k   ok
normal  38:     1.1 mb     1.1 mb     1.1 mb     6.0 kb     200     ok
normal  39:   166.5 mb   236.1 mb   236.1 mb     7.0 kb    34.5 k   ok
normal  40:    27.4 mb    33.5 mb    33.5 mb     8.0 kb     4.3 k   ok
normal  41:     1.9 mb     1.9 mb     1.9 mb    10.0 kb     200     ok
normal  42:     2.3 mb     2.3 mb     2.3 mb    12.0 kb     200     ok
normal  43:   127.1 mb   127.1 mb   127.1 mb    14.0 kb     9.3 k   ok
normal  44:    56.1 mb    67.1 mb    67.1 mb    16.0 kb     4.3 k   ok
normal  47:   248.8 mb   248.8 mb   248.8 mb    28.1 kb     9.1 k   ok
normal  48:   106.3 mb   137.5 mb   137.5 mb    32.1 kb     4.4 k   ok
normal  49:     2.8 gb     2.8 gb     2.8 gb    40.1 kb    75.8 k   ok
normal  52:   214.5 mb   278.1 mb   278.1 mb    64.2 kb     4.4 k   ok
normal  53:    88.2 mb    89.8 mb    89.8 mb    80.3 kb     1.1 k   ok
normal  56:    75.0 mb    75.0 mb    75.0 mb   128.5 kb     600     ok
normal  57:    84.5 mb    85.9 mb    85.9 mb   160.6 kb     550     ok
normal  60:   387.5 mb   387.5 mb   387.5 mb   257.0 kb     1.5 k   ok
normal  61:   181.8 mb   187.5 mb   187.5 mb   321.2 kb     600     ok
normal  63:   700.0 mb   700.0 mb   700.0 mb   449.7 kb     1.6 k   ok
normal  65:   460.0 mb   531.2 mb   531.2 mb   642.5 kb     850     ok

heap stats:     peak      total      freed       unit      count
    normal:     6.3 gb     6.7 gb     6.7 gb       1 b              not all freed!
      huge:     1.2 g      1.2 g      1.2 g      1.8 mb     700     not all freed!
     giant:       0 b        0 b        0 b        1 b              ok
     total:     7.6 gb     8.0 gb     8.0 gb       1 b              not all freed!
malloc requested:          7.5 gb

  reserved:   386.1 mb   792.5 mb   408.5 mb       1 b              not all freed!
 committed:   506.5 mb   525.0 mb    18.9 mb       1 b              not all freed!
     reset:       0 b        0 b        0 b        1 b              ok
   touched:     7.1 gb     7.7 gb     7.7 gb       1 b              ok
  segments:    13.0 k     15.2 k     15.2 k                         not all freed!
-abandoned:     1.2 k      4.4 k      4.4 k                         not all freed!
   -cached:       0          0          0                           ok
     pages:    51.2 k     61.5 k     61.4 k                         not all freed!
-abandoned:     8.7 k     20.6 k     20.6 k                         not all freed!
 -extended:   295.9 k
 -noretire:    31.5 k
     mmaps:     1.5 k
   commits:     661
   threads:      27        1.5 k      3.1 k                         ok
  searches:     0.9 avg
numa nodes:       1
   elapsed:       5.789 s
   process: user: 23.423 s, system: 0.252 s, faults: 0, rss: 367.4 mb, commit: 506.5 mb


```
```
(gdb) info frame
Stack level 0, frame at 0xffffd5b0:
 rip = 0x56559526 in main (/root/src/mimalloc/test/test-api.c:88); saved rip = 0xf7e0bdbd
 source language c.
 Arglist at 0xffffd5a0, args:
 Locals at 0xffffd5a0, Previous frame's sp is 0xffffd5b0
 Saved registers:
  rbp at 0xffffd5a0, rip at 0xffffd5a8

```