### PR TITLE
Do not use the same counter for warnings and errors

### DIFF
--- a/include/mimalloc.h
+++ b/include/mimalloc.h
@@ -317,6 +317,7 @@ typedef enum mi_option_e {
   mi_option_limit_os_alloc,
   mi_option_os_tag,
   mi_option_max_errors,
+  mi_option_max_warnings,
   _mi_option_last
 } mi_option_t;
 

--- a/src/options.c
+++ b/src/options.c
@@ -19,7 +19,8 @@ terms of the MIT license. A copy of the license can be found in the file
 #endif
 
 
-static uintptr_t mi_max_error_count = 16;  // stop outputting errors after this
+static uintptr_t mi_max_error_count   = -1ULL; // stop outputting errors after this
+static uintptr_t mi_max_warning_count = 16;  // stop outputting warnings after this
 
 static void mi_add_stderr_output();
 
@@ -89,7 +90,8 @@ static mi_option_desc_t options[_mi_option_last] =
   { 0,   UNINIT, MI_OPTION(use_numa_nodes) },    // 0 = use available numa nodes, otherwise use at most N nodes.
   { 0,   UNINIT, MI_OPTION(limit_os_alloc) },    // 1 = do not use OS memory for allocation (but only reserved arenas)
   { 100, UNINIT, MI_OPTION(os_tag) },            // only apple specific for now but might serve more or less related purpose
-  { 16,  UNINIT, MI_OPTION(max_errors) }         // maximum errors that are output
+  { 16,  UNINIT, MI_OPTION(max_warnings) },      // maximum warnings that are output
+  { -1ULL, UNINIT, MI_OPTION(max_errors) }       // maximum errors that are output
 };
 
 static void mi_option_init(mi_option_desc_t* desc);
@@ -107,6 +109,7 @@ void _mi_options_init(void) {
     }
   }
   mi_max_error_count = mi_option_get(mi_option_max_errors);
+  mi_max_warning_count = mi_option_get(mi_option_max_warnings);
 }
 
 long mi_option_get(mi_option_t option) {
@@ -325,7 +328,7 @@ static void mi_show_error_message(const char* fmt, va_list args) {
 
 void _mi_warning_message(const char* fmt, ...) {
   if (!mi_option_is_enabled(mi_option_show_errors) && !mi_option_is_enabled(mi_option_verbose)) return;
-  if (mi_atomic_increment_acq_rel(&error_count) > mi_max_error_count) return;
+  if (mi_atomic_increment_acq_rel(&error_count) > mi_max_warning_count) return;
   va_list args;
   va_start(args,fmt);
   mi_vfprintf(NULL, NULL, "mimalloc: warning: ", fmt, args);


### PR DESCRIPTION
Warnings happen normally and could be safely ignored in the most cases, however errors, if enabled, should not be ignored. Currently since warnings and errors share the same counter we effectively stop showing errors after 16 warnings (which happen all the time).

Use different counters for errors and warnings to fix this issue.