### PR TITLE
Don't set march=native on Apple Silicon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,7 +187,10 @@ endif()
 
 # Architecture flags
 if(${CMAKE_HOST_SYSTEM_PROCESSOR} MATCHES "arm" AND NOT APPLE)
-    list(APPEND mi_cflags -march=native)
+    check_cxx_compiler_flag(-march=native CXX_SUPPORTS_MARCH_NATIVE)
+    if (CXX_SUPPORTS_MARCH_NATIVE)
+        list(APPEND mi_cflags -march=native)
+    endif()
 endif()
 
 # extra needed libraries

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,7 +186,7 @@ if(CMAKE_C_COMPILER_ID MATCHES "AppleClang|Clang|GNU|Intel" AND NOT CMAKE_SYSTEM
 endif()
 
 # Architecture flags
-if(${CMAKE_HOST_SYSTEM_PROCESSOR} MATCHES "arm")
+if(${CMAKE_HOST_SYSTEM_PROCESSOR} MATCHES "arm" AND NOT APPLE)
     list(APPEND mi_cflags -march=native)
 endif()
 


### PR DESCRIPTION
Fixes #340 

There is the alternative between not stetting anything and using `march=armv8`. From my understanding, they produce exactly the same results for now.