### PR TITLE
Use lower-case include filenames to improve compatibility with MinGW.

### DIFF
--- a/include/mimalloc-atomic.h
+++ b/include/mimalloc-atomic.h
@@ -118,7 +118,7 @@ static inline void mi_atomic_maxi64_relaxed(volatile int64_t* p, int64_t x) {
 
 // MSVC C compilation wrapper that uses Interlocked operations to model C11 atomics.
 #define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
+#include <windows.h>
 #include <intrin.h>
 #ifdef _WIN64
 typedef LONG64   msc_intptr_t;

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -726,7 +726,7 @@ mi_decl_restrict char* mi_strndup(const char* s, size_t n) mi_attr_noexcept {
 #ifndef PATH_MAX
 #define PATH_MAX MAX_PATH
 #endif
-#include <Windows.h>
+#include <windows.h>
 mi_decl_restrict char* mi_heap_realpath(mi_heap_t* heap, const char* fname, char* resolved_name) mi_attr_noexcept {
   // todo: use GetFullPathNameW to allow longer file names
   char buf[PATH_MAX];

--- a/src/init.c
+++ b/src/init.c
@@ -309,7 +309,7 @@ static void _mi_thread_done(mi_heap_t* default_heap);
   // nothing to do as it is done in DllMain
 #elif defined(_WIN32) && !defined(MI_SHARED_LIB)
   // use thread local storage keys to detect thread ending
-  #include <Windows.h>
+  #include <windows.h>
   #include <fibersapi.h>
   #if (_WIN32_WINNT < 0x600)  // before Windows Vista 
   WINBASEAPI DWORD WINAPI FlsAlloc( _In_opt_ PFLS_CALLBACK_FUNCTION lpCallback );

--- a/src/options.c
+++ b/src/options.c
@@ -425,7 +425,7 @@ static inline int mi_strnicmp(const char* s, const char* t, size_t n) {
 // reliably even when this is invoked before the C runtime is initialized.
 // i.e. when `_mi_preloading() == true`.
 // Note: on windows, environment names are not case sensitive.
-#include <Windows.h>
+#include <windows.h>
 static bool mi_getenv(const char* name, char* result, size_t result_size) {
   result[0] = 0;
   size_t len = GetEnvironmentVariableA(name, result, (DWORD)result_size);

--- a/src/os.c
+++ b/src/os.c
@@ -28,7 +28,7 @@ terms of the MIT license. A copy of the license can be found in the file
 
 
 #if defined(_WIN32)
-#include <Windows.h>
+#include <windows.h>
 #elif defined(__wasi__)
 // stdlib.h is all we need, and has already been included in mimalloc.h
 #else

--- a/src/random.c
+++ b/src/random.c
@@ -244,7 +244,7 @@ static bool os_random_buf(void* buf, size_t buf_len) {
 #endif
 
 #if defined(_WIN32)
-#include <Windows.h>
+#include <windows.h>
 #elif defined(__APPLE__)
 #include <mach/mach_time.h>
 #else

--- a/src/stats.c
+++ b/src/stats.c
@@ -393,7 +393,7 @@ void mi_thread_stats_print_out(mi_output_fun* out, void* arg) mi_attr_noexcept {
 // Basic timer for convenience; use milli-seconds to avoid doubles
 // ----------------------------------------------------------------
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 static mi_msecs_t mi_to_msecs(LARGE_INTEGER t) {
   static LARGE_INTEGER mfreq; // = 0
   if (mfreq.QuadPart == 0LL) {
@@ -448,7 +448,7 @@ mi_msecs_t _mi_clock_end(mi_msecs_t start) {
 // --------------------------------------------------------
 
 #if defined(_WIN32)
-#include <Windows.h>
+#include <windows.h>
 #include <psapi.h>
 #pragma comment(lib,"psapi.lib")
 

--- a/test/main-override.cpp
+++ b/test/main-override.cpp
@@ -19,7 +19,7 @@
 #endif
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 static void msleep(unsigned long msecs) { Sleep(msecs); }
 #else
 #include <unistd.h>

--- a/test/test-stress.c
+++ b/test/test-stress.c
@@ -273,7 +273,7 @@ static void (*thread_entry_fun)(intptr_t) = &stress;
 
 #ifdef _WIN32
 
-#include <Windows.h>
+#include <windows.h>
 
 static DWORD WINAPI thread_entry(LPVOID param) {
   thread_entry_fun((intptr_t)param);


### PR DESCRIPTION
I ran into an issue attempting to cross-compile a Windows version of [SolveSpace](https://github.com/solvespace/solvespace) from WSL. It looks like the issue boils down to case sensitivity of included header files. Normalizing "Windows.h" to "windows.h" fixed the problem for me.