### PR TITLE
[Windows] Correctly choose 32-bit version of mimalloc-redirect{,32}.dll in CMake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,10 +265,16 @@ if(MI_BUILD_SHARED)
   )
   if(WIN32)
     # On windows copy the mimalloc redirection dll too.
-    target_link_libraries(mimalloc PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/bin/mimalloc-redirect.lib)
+    if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+      set(MIMALLOC_REDIRECT_SUFFIX "32")
+    else()
+      set(MIMALLOC_REDIRECT_SUFFIX "")
+    endif()
+
+    target_link_libraries(mimalloc PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/bin/mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.lib)
     add_custom_command(TARGET mimalloc POST_BUILD
-      COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_CURRENT_SOURCE_DIR}/bin/mimalloc-redirect.dll" $<TARGET_FILE_DIR:mimalloc>
-      COMMENT "Copy mimalloc-redirect.dll to output directory")
+      COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_CURRENT_SOURCE_DIR}/bin/mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.dll" $<TARGET_FILE_DIR:mimalloc>
+      COMMENT "Copy mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.dll to output directory")
   endif()
 
   if (MI_INSTALL_TOPLEVEL MATCHES "ON")


### PR DESCRIPTION
This fixes the use of mimalloc on 32-bit Windows when building with CMake.
Without it, one would get link errors like:
```
      init.obj error LNK2019: unresolved external symbol __imp__mi_allocator_init referenced in function "void __cdecl mi_process_load(void)" (?mi_process_load@@YAXXZ)
10:58:29
      init.obj error LNK2019: unresolved external symbol __imp__mi_allocator_done referenced in function "void __cdecl mi_process_done(void)" (?mi_process_done@@YAXXZ)
10:58:29
      ..\..\..\..\thirdparty\mimalloc\bin\mimalloc-redirect.lib warning LNK4272: library machine type 'x64' conflicts with target machine type 'x86'
```
because it would try to link `bin\mimalloc-redirect.lib` (64-bit) to a 32-bit mimalloc.dll.

Also, without this patch, `bin\mimalloc-redirect32.{lib,dll}` are unused in CMake, they are used though in .vcxproj files.