### PR TITLE
[CMake] Respect CMAKE_INSTALL_PREFIX at install time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,9 +208,9 @@ endif()
 # -----------------------------------------------------------------------------
 
 if (MI_INSTALL_TOPLEVEL)
-  set(mi_install_dir "${CMAKE_INSTALL_PREFIX}")
+  set(mi_install_dir "")
 else()
-  set(mi_install_dir "${CMAKE_INSTALL_PREFIX}/lib/mimalloc-${mi_version}")
+  set(mi_install_dir "lib/mimalloc-${mi_version}")
 endif()
 
 if(MI_SECURE)


### PR DESCRIPTION
The standard way of cmake install to a destination folder is the following pattern:
```shell
cd <BUILD_DIR>
cmake <SRC_DIR>
cmake --build <BUILD_DIR>
cmake --install <BUILD_DIR> --prefix <INSTALL_DIR>
```
Right now, the `<INSTALL_DIR>` folder passed in cmake --install command is ignored,
and always installed into `C:/Program Files(x86)/...`, which is the default
`CMAKE_INSTALL_PREFIX` value passed at the `cmake <SRC_DIR>` call.
Thus, it is not possible to install the binaries into different folders
without rerun the cmake/build process.

The important thing here is, the cmake variable `CMAKE_INSTALL_PREFIX`
is supposed to be passed at `cmake --install` time with the `--prefix` argument.
In cmake file, `install` with relative path will use that prefix automaticlly.
And it is the best practice to not include CMAKE_INSTALL_PREFIX
in the `install(... DESTINATION )` argument:
```
In particular, there is no need to make paths absolute by prepending
CMAKE_INSTALL_PREFIX; this prefix is used by default if the DESTINATION is a relative path.
```
referenced from: https://cmake.org/cmake/help/latest/command/install.html