### PR TITLE
Change internal include  to use double quote

### DIFF
--- a/include/mimalloc-new-delete.h
+++ b/include/mimalloc-new-delete.h
@@ -20,7 +20,7 @@ terms of the MIT license. A copy of the license can be found in the file
 // ---------------------------------------------------------------------------
 #if defined(__cplusplus)
   #include <new>
-  #include <mimalloc.h>
+  #include "mimalloc.h"
 
   void operator delete(void* p) noexcept              { mi_free(p); };
   void operator delete[](void* p) noexcept            { mi_free(p); };

--- a/include/mimalloc-override.h
+++ b/include/mimalloc-override.h
@@ -15,7 +15,7 @@ each source file in a project (but be careful when using external code to
 not accidentally mix pointers from different allocators).
 -----------------------------------------------------------------------------*/
 
-#include <mimalloc.h>
+#include "mimalloc.h"
 
 // Standard C allocation
 #define malloc(n)               mi_malloc(n)

--- a/include/mimalloc-types.h
+++ b/include/mimalloc-types.h
@@ -10,7 +10,7 @@ terms of the MIT license. A copy of the license can be found in the file
 
 #include <stddef.h>   // ptrdiff_t
 #include <stdint.h>   // uintptr_t, uint16_t, etc
-#include <mimalloc-atomic.h>  // _Atomic
+#include "mimalloc-atomic.h"  // _Atomic
 
 #ifdef _MSC_VER
 #pragma warning(disable:4214) // bitfield is not int


### PR DESCRIPTION
Hello

I changed the include <> to include "" for internal include that is in the same folder.

It fix the requirement to add an include directory in the makefile when we embed the file in an other object.

Thanks