### PR TITLE
Add spaces after uses of _Atomic() to prevent it from expanding as a prefix to the following identifier when compiling with MSVC as C

### DIFF
--- a/include/mimalloc-atomic.h
+++ b/include/mimalloc-atomic.h
@@ -173,7 +173,7 @@ static inline uintptr_t mi_atomic_exchange_explicit(_Atomic(uintptr_t)*p, uintpt
 }
 static inline void mi_atomic_thread_fence(mi_memory_order mo) {
   (void)(mo);
-  _Atomic(uintptr_t)x = 0;
+  _Atomic(uintptr_t) x = 0;
   mi_atomic_exchange_explicit(&x, 1, mo);
 }
 static inline uintptr_t mi_atomic_load_explicit(_Atomic(uintptr_t) const* p, mi_memory_order mo) {

--- a/src/segment-cache.c
+++ b/src/segment-cache.c
@@ -225,7 +225,7 @@ mi_decl_noinline bool _mi_segment_cache_push(void* start, size_t size, size_t me
 #define MI_SEGMENT_MAP_SIZE  (MI_SEGMENT_MAP_BITS / 8)
 #define MI_SEGMENT_MAP_WSIZE (MI_SEGMENT_MAP_SIZE / MI_INTPTR_SIZE)
 
-static _Atomic(uintptr_t)mi_segment_map[MI_SEGMENT_MAP_WSIZE];  // 2KiB per TB with 64MiB segments
+static _Atomic(uintptr_t) mi_segment_map[MI_SEGMENT_MAP_WSIZE];  // 2KiB per TB with 64MiB segments
 
 static size_t mi_segment_map_index_of(const mi_segment_t* segment, size_t* bitidx) {
   mi_assert_internal(_mi_ptr_segment(segment) == segment); // is it aligned on MI_SEGMENT_SIZE?


### PR DESCRIPTION
Seen when compiling Mimalloc as part of Unreal Engine with FASTBuild.

Compiling with MSVC as C results in some variables having their types concatenated with their names.

e.g. 
```
_Atomic(uintptr_t)x = 0;
```
becomes
```
uintptr_tx = 0;
```

e.g.
```
static _Atomic(uintptr_t)mi_segment_map[MI_SEGMENT_MAP_WSIZE];
```
becomes
```
static uintptr_tmi_segment_map[MI_SEGMENT_MAP_WSIZE];
```