### PR TITLE
Add an option to disable environment access inside options.c

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -409,6 +409,14 @@ static void mi_strlcat(char* dest, const char* src, size_t dest_size) {
   dest[dest_size - 1] = 0;
 }
 
+#ifdef MI_NO_GETENV
+static bool mi_getenv(const char* name, char* result, size_t result_size) {
+  UNUSED(name);
+  UNUSED(result);
+  UNUSED(result_size);
+  return false;
+}
+#else
 static inline int mi_strnicmp(const char* s, const char* t, size_t n) {
   if (n==0) return 0;
   for (; *s != 0 && *t != 0 && n > 0; s++, t++, n--) {
@@ -416,7 +424,6 @@ static inline int mi_strnicmp(const char* s, const char* t, size_t n) {
   }
   return (n==0 ? 0 : *s - *t);
 }
-
 #if defined _WIN32
 // On Windows use GetEnvironmentVariable instead of getenv to work
 // reliably even when this is invoked before the C runtime is initialized.
@@ -484,6 +491,7 @@ static bool mi_getenv(const char* name, char* result, size_t result_size) {
     return false;
   }
 }
+#endif
 #endif
 
 static void mi_option_init(mi_option_desc_t* desc) {  


### PR DESCRIPTION
There are some cases where it would be nice to guarantee that mimalloc doesn't access the environment without being told to, so this patch allows someone who cares enough to build with `-DMI_NO_GETENV` to turn it off.

1. On many platforms it is thread-unsafe in the context of multithreaded use of setenv, which is my case (for better or worse this is allowed by the Rust standard library).
2. I could also cases where you wouldn't want the behavior to depend on the runtime environment of where you're shipping a mimalloc-using program, but this isn't my use case.

This doesn't need to disable the environment-access functions mimalloc defines, just environment access that occurs at an unprompted time. Plausibly, someone might call mi_dupenv or whatever when they "know" the access is threadsafe.

Strictly speaking, for my use case I believe it doesn't need to disable it on windows either, since I think `GetEnvironmentVariableA` and friends don't have the same thread safety issues, but if someone cares, they can do that when performing the build, and this way it allows serving use case 2 as well, to some extent.

I don't need to expose this via cmake, since I don't build mimalloc that way (Also, it's a niche enough issue need that it might not be worth exposing in that manner), but if you'd like me to I can.

Note: in addition to the definition of `mi_getenv`, `mi_strnicmp` is also inside the `#else` — otherwise an unused function warning is emitted when building with `MI_NO_GETENV` enabled.