### PR TITLE
Fix strict function prototype warnings

### DIFF
--- a/include/mimalloc-internal.h
+++ b/include/mimalloc-internal.h
@@ -53,7 +53,7 @@ static inline uintptr_t _mi_random_shuffle(uintptr_t x);
 extern mi_decl_cache_align mi_stats_t       _mi_stats_main;
 extern mi_decl_cache_align const mi_page_t  _mi_page_empty;
 bool       _mi_is_main_thread(void);
-bool       _mi_preloading();  // true while the C runtime is not ready
+bool       _mi_preloading(void);  // true while the C runtime is not ready
 
 // os.c
 size_t     _mi_os_page_size(void);

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -747,7 +747,7 @@ mi_decl_restrict char* mi_heap_realpath(mi_heap_t* heap, const char* fname, char
 }
 #else
 #include <unistd.h>  // pathconf
-static size_t mi_path_max() {
+static size_t mi_path_max(void) {
   static size_t path_max = 0;
   if (path_max <= 0) {
     long m = pathconf("/",_PC_PATH_MAX);
@@ -807,13 +807,13 @@ static bool mi_try_new_handler(bool nothrow) {
   }
 }
 #else
-typedef void (*std_new_handler_t)();
+typedef void (*std_new_handler_t)(void);
 
 #if (defined(__GNUC__) || defined(__clang__))
-std_new_handler_t __attribute((weak)) _ZSt15get_new_handlerv() {
+std_new_handler_t __attribute((weak)) _ZSt15get_new_handlerv(void) {
   return NULL;
 }
-static std_new_handler_t mi_get_new_handler() {
+static std_new_handler_t mi_get_new_handler(void) {
   return _ZSt15get_new_handlerv();
 }
 #else

--- a/src/options.c
+++ b/src/options.c
@@ -22,7 +22,7 @@ terms of the MIT license. A copy of the license can be found in the file
 static uintptr_t mi_max_error_count   = 16; // stop outputting errors after this
 static uintptr_t mi_max_warning_count = 16; // stop outputting warnings after this
 
-static void mi_add_stderr_output();
+static void mi_add_stderr_output(void);
 
 int mi_version(void) mi_attr_noexcept {
   return MI_MALLOC_VERSION;

--- a/src/os.c
+++ b/src/os.c
@@ -95,7 +95,7 @@ size_t _mi_os_page_size() {
 }
 
 // if large OS pages are supported (2 or 4MiB), then return the size, otherwise return the small page size (4KiB)
-size_t _mi_os_large_page_size() {
+size_t _mi_os_large_page_size(void) {
   return (large_os_page_size != 0 ? large_os_page_size : _mi_os_page_size());
 }
 

--- a/src/region.c
+++ b/src/region.c
@@ -40,7 +40,7 @@ Possible issues:
 #include "bitmap.h"
 
 // Internal raw OS interface
-size_t  _mi_os_large_page_size();
+size_t  _mi_os_large_page_size(void);
 bool    _mi_os_protect(void* addr, size_t size);
 bool    _mi_os_unprotect(void* addr, size_t size);
 bool    _mi_os_commit(void* p, size_t size, bool* is_zero, mi_stats_t* stats);

--- a/test/test-api.c
+++ b/test/test-api.c
@@ -64,15 +64,15 @@ static int failed = 0;
 // ---------------------------------------------------------------------------
 // Test functions
 // ---------------------------------------------------------------------------
-bool test_heap1();
-bool test_heap2();
-bool test_stl_allocator1();
-bool test_stl_allocator2();
+bool test_heap1(void);
+bool test_heap2(void);
+bool test_stl_allocator1(void);
+bool test_stl_allocator2(void);
 
 // ---------------------------------------------------------------------------
 // Main testing
 // ---------------------------------------------------------------------------
-int main() {
+int main(void) {
   mi_option_disable(mi_option_verbose);
 
   // ---------------------------------------------------


### PR DESCRIPTION
Fix warning ``warning: function declaration isn’t a prototype`` when
building mimalloc with ``-Wstrict-prototypes`` flag. In C argumentless
functions should be declared as ``func(void)``.

Reproducer:
```shell
$ cmake ../.. -DCMAKE_C_FLAGS="-Wstrict-prototypes"
$ make VERBOSE=1
```

Co-authored-by: Sam Gross <colesbury@gmail.com>
Co-authored-by: Neil Schemenauer <nas@arctrix.com>
Signed-off-by: Christian Heimes <christian@python.org>