### PR TITLE
Define _DEFAULT_SOURCE for syscall and realpath

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -4,6 +4,10 @@ This is free software; you can redistribute it and/or modify it under the
 terms of the MIT license. A copy of the license can be found in the file
 "LICENSE" at the root of this distribution.
 -----------------------------------------------------------------------------*/
+#ifndef _DEFAULT_SOURCE
+#define _DEFAULT_SOURCE   // for realpath() on Linux
+#endif
+
 #include "mimalloc.h"
 #include "mimalloc-internal.h"
 #include "mimalloc-atomic.h"

--- a/src/random.c
+++ b/src/random.c
@@ -4,6 +4,10 @@ This is free software; you can redistribute it and/or modify it under the
 terms of the MIT license. A copy of the license can be found in the file
 "LICENSE" at the root of this distribution.
 -----------------------------------------------------------------------------*/
+#ifndef _DEFAULT_SOURCE
+#define _DEFAULT_SOURCE   // for syscall() on Linux
+#endif
+
 #include "mimalloc.h"
 #include "mimalloc-internal.h"
 


### PR DESCRIPTION
Define ``_DEFAULT_SOURCE`` in ``random.c`` and ``alloc.c``. The macro
is required for ``syscall()`` and ``realpath()``. Other files like
``os.c`` already define the macro.

Signed-off-by: Christian Heimes <christian@python.org>