### PR TITLE
Fix building on Windows ARM64

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -571,7 +571,7 @@ static void mi_process_done(void) {
     return 0;
   }
   typedef int(*_crt_cb)(void);
-  #ifdef _M_X64
+  #if defined(_M_X64) || defined(_M_ARM64)
     __pragma(comment(linker, "/include:" "_mi_msvc_initu"))
     #pragma section(".CRT$XIU", long, read)
   #else


### PR DESCRIPTION
Fixes ``error LNK2001: unresolved external symbol __mi_msvc_initu``

Fixes: https://github.com/microsoft/mimalloc/issues/426
Co-authored-by: Mojca Miklavec <mojca.miklavec@gmail.com>
Signed-off-by: Christian Heimes <christian@python.org>