### PR TITLE
Rename _os_random_weak to _mi_os_random_weak

### DIFF
--- a/include/mimalloc-internal.h
+++ b/include/mimalloc-internal.h
@@ -50,7 +50,7 @@ void       _mi_random_init(mi_random_ctx_t* ctx);
 void       _mi_random_split(mi_random_ctx_t* ctx, mi_random_ctx_t* new_ctx);
 uintptr_t  _mi_random_next(mi_random_ctx_t* ctx);
 uintptr_t  _mi_heap_random_next(mi_heap_t* heap);
-uintptr_t  _os_random_weak(uintptr_t extra_seed);
+uintptr_t  _mi_os_random_weak(uintptr_t extra_seed);
 static inline uintptr_t _mi_random_shuffle(uintptr_t x);
 
 // init.c

--- a/src/init.c
+++ b/src/init.c
@@ -141,7 +141,7 @@ mi_stats_t _mi_stats_main = { MI_STATS_NULL };
 static void mi_heap_main_init(void) {
   if (_mi_heap_main.cookie == 0) {
     _mi_heap_main.thread_id = _mi_thread_id();
-    _mi_heap_main.cookie = _os_random_weak((uintptr_t)&mi_heap_main_init);
+    _mi_heap_main.cookie = _mi_os_random_weak((uintptr_t)&mi_heap_main_init);
     _mi_random_init(&_mi_heap_main.random);
     _mi_heap_main.keys[0] = _mi_heap_random_next(&_mi_heap_main);
     _mi_heap_main.keys[1] = _mi_heap_random_next(&_mi_heap_main);

--- a/src/random.c
+++ b/src/random.c
@@ -257,8 +257,8 @@ static bool os_random_buf(void* buf, size_t buf_len) {
 #include <time.h>
 #endif
 
-uintptr_t _os_random_weak(uintptr_t extra_seed) {
-  uintptr_t x = (uintptr_t)&_os_random_weak ^ extra_seed; // ASLR makes the address random
+uintptr_t _mi_os_random_weak(uintptr_t extra_seed) {
+  uintptr_t x = (uintptr_t)&_mi_os_random_weak ^ extra_seed; // ASLR makes the address random
   
   #if defined(_WIN32)
     LARGE_INTEGER pcount;
@@ -289,7 +289,7 @@ void _mi_random_init(mi_random_ctx_t* ctx) {
     #if !defined(__wasi__)
     _mi_warning_message("unable to use secure randomness\n");
     #endif
-    uintptr_t x = _os_random_weak(0);
+    uintptr_t x = _mi_os_random_weak(0);
     for (size_t i = 0; i < 8; i++) {  // key is eight 32-bit words.
       x = _mi_random_shuffle(x);
       ((uint32_t*)key)[i] = (uint32_t)x;


### PR DESCRIPTION
The ``_os_random_weak`` function is the only non-static function
besides ``_ZSt15get_new_handlerv`` that is not prefixed with ``mi`` or
``_mi``.

The discrepancy was discovered by CPython's smelly script. The checker
looks for exported symbols that don't have well-defined prefixes.

Signed-off-by: Christian Heimes <christian@python.org>