### PR TITLE
Fix preload path in documentation example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ Latest stable  tag: `v1.7.2` (2021-06-17).
 mimalloc is a drop-in replacement for `malloc` and can be used in other programs
 without code changes, for example, on dynamically linked ELF-based systems (Linux, BSD, etc.) you can use it as:
 ```
-> LD_PRELOAD=/usr/bin/libmimalloc.so  myprogram
+> LD_PRELOAD=/usr/lib/libmimalloc.so  myprogram
 ```
 It also has an easy way to override the default allocator in [Windows](#override_on_windows). Notable aspects of the design include:
 


### PR DESCRIPTION
The .so files are usually in `/usr/lib`, not `/usr/bin`. The updated path is the same as below in the text.