### PR TITLE
Android segfault fix.

### DIFF
--- a/include/mimalloc-internal.h
+++ b/include/mimalloc-internal.h
@@ -317,6 +317,8 @@ mi_heap_t*  _mi_heap_main_get(void);    // statically allocated main backing hea
 #elif defined(__DragonFly__)
 #warning "mimalloc is not working correctly on DragonFly yet."
 //#define MI_TLS_PTHREAD_SLOT_OFS   (4 + 1*sizeof(void*))  // offset `uniqueid` (also used by gdb?) <https://github.com/DragonFlyBSD/DragonFlyBSD/blob/master/lib/libthread_xu/thread/thr_private.h#L458>
+#elif defined(__ANDROID__)
+#define MI_TLS_PTHREAD
 #endif
 #endif
 
@@ -766,7 +768,7 @@ static inline void mi_tls_slot_set(size_t slot, void* value) mi_attr_noexcept {
 }
 
 static inline mi_threadid_t _mi_thread_id(void) mi_attr_noexcept {
-#if defined(__BIONIC__) && (defined(__arm__) || defined(__aarch64__))
+#if defined(__ANDROID__) && (defined(__arm__) || defined(__aarch64__))
   // on Android, slot 1 is the thread ID (pointer to pthread internal struct)
   return (uintptr_t)mi_tls_slot(1);
 #else


### PR DESCRIPTION
Using MI_TLS_PTHREAD for this platform instead.