### PR TITLE
Pull request for issue #490:  set SOVERSION for mimalloc shared lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,7 +280,7 @@ message(STATUS "")
 # shared library
 if(MI_BUILD_SHARED)
   add_library(mimalloc SHARED ${mi_sources})
-  set_target_properties(mimalloc PROPERTIES VERSION ${mi_version} OUTPUT_NAME ${mi_basename} )
+  set_target_properties(mimalloc PROPERTIES VERSION ${mi_version} SOVERSION ${mi_version_major} OUTPUT_NAME ${mi_basename} )
   target_compile_definitions(mimalloc PRIVATE ${mi_defines} MI_SHARED_LIB MI_SHARED_LIB_EXPORT)
   target_compile_options(mimalloc PRIVATE ${mi_cflags})
   target_link_libraries(mimalloc PUBLIC ${mi_libraries})
@@ -336,16 +336,6 @@ install(FILES include/mimalloc-new-delete.h DESTINATION ${mi_install_incdir})
 install(FILES cmake/mimalloc-config.cmake DESTINATION ${mi_install_cmakedir})
 install(FILES cmake/mimalloc-config-version.cmake DESTINATION ${mi_install_cmakedir})
 
-if(NOT WIN32 AND MI_BUILD_SHARED AND NOT MI_INSTALL_TOPLEVEL)
-  # install a symlink in the /usr/local/lib to the versioned library
-  # note: use delayed prefix expansion as \${CMAKE_INSTALL_PREFIX}
-  set(mi_symlink "${CMAKE_SHARED_MODULE_PREFIX}${mi_basename}${CMAKE_SHARED_LIBRARY_SUFFIX}")
-  set(mi_soname "mimalloc-${mi_version}/${mi_symlink}.${mi_version}")
-  install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ${mi_soname} ${mi_symlink} WORKING_DIRECTORY \${CMAKE_INSTALL_PREFIX}/lib)")
-  install(CODE "MESSAGE(\"-- Symbolic link: \${CMAKE_INSTALL_PREFIX}/lib/${mi_symlink} -> ${mi_soname}\")")
-  install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ${mi_soname} ${mi_symlink}.${mi_version} WORKING_DIRECTORY \${CMAKE_INSTALL_PREFIX}/lib)")
-  install(CODE "MESSAGE(\"-- Symbolic link: \${CMAKE_INSTALL_PREFIX}/lib/${mi_symlink}.${mi_version} -> ${mi_soname}\")")
-endif()
 
 # single object file for more predictable static overriding
 if (MI_BUILD_OBJECT)

--- a/cmake/mimalloc-config-version.cmake
+++ b/cmake/mimalloc-config-version.cmake
@@ -1,6 +1,7 @@
 set(mi_version_major 1)
 set(mi_version_minor 7)
-set(mi_version ${mi_version_major}.${mi_version_minor})
+set(mi_version_patch 3)
+set(mi_version ${mi_version_major}.${mi_version_minor}.${mi_version_patch})
 
 set(PACKAGE_VERSION ${mi_version})
 if(PACKAGE_FIND_VERSION_MAJOR)


### PR DESCRIPTION
This is the pull request for the issue490: mimalloc: set SOVERSION for mimalloc shared lib (required for proper unix builds) #490 

The reason is following:
SOVERSION is required for proper unix builds.

comments on the proposed patches:
A) in CMakeLists.txt 
   1)  add SOVERSION ${mi_version_major}

   2) remove the hack with symlinks:
    -if(NOT WIN32 AND MI_BUILD_SHARED AND NOT MI_INSTALL_TOPLEVEL)
    ...
    endif()

first, it does thing wrong on unix, and, second, when we set SOVERSION, cmake will do it for us, and will do it properly.

B)
    it is optional, but it would be nice to show .so.version as real version 2.0.3, not 2.0
    for this, in cmake/mimalloc-config-version.cmake
    -set(mi_version ${mi_version_major}.${mi_version_minor})
    +set(mi_version_patch 3)
    +set(mi_version ${mi_version_major}.${mi_version_minor}.${mi_version_patch})
