### PR TITLE
Try to consistently fill memory with MI_DEBUG_UNINIT in debug mode

### DIFF
--- a/include/mimalloc-internal.h
+++ b/include/mimalloc-internal.h
@@ -148,6 +148,10 @@ void        _mi_block_zero_init(const mi_page_t* page, void* p, size_t size);
 bool        _mi_page_is_valid(mi_page_t* page);
 #endif
 
+#if MI_DEBUG >= 2
+void        _mi_debug_uninit_fill(void* p, size_t size);
+#endif
+
 
 // ------------------------------------------------------
 // Branches

--- a/include/mimalloc-internal.h
+++ b/include/mimalloc-internal.h
@@ -138,8 +138,8 @@ mi_msecs_t  _mi_clock_start(void);
 
 // "alloc.c"
 void*       _mi_page_malloc(mi_heap_t* heap, mi_page_t* page, size_t size) mi_attr_noexcept;  // called from `_mi_malloc_generic`
-void*       _mi_heap_malloc_zero(mi_heap_t* heap, size_t size, mi_alloc_init_t init);
-void*       _mi_heap_realloc_zero(mi_heap_t* heap, void* p, size_t newsize, mi_alloc_init_t init);
+void*       _mi_heap_malloc_init(mi_heap_t* heap, size_t size, mi_alloc_init_t init) mi_attr_noexcept;
+void*       _mi_heap_realloc_init(mi_heap_t* heap, void* p, size_t newsize, mi_alloc_init_t init);
 mi_block_t* _mi_page_ptr_unalign(const mi_segment_t* segment, const mi_page_t* page, const void* p);
 bool        _mi_free_delayed_block(mi_block_t* block);
 void        _mi_block_zero_init(const mi_page_t* page, void* p, size_t size);

--- a/include/mimalloc-internal.h
+++ b/include/mimalloc-internal.h
@@ -138,8 +138,8 @@ mi_msecs_t  _mi_clock_start(void);
 
 // "alloc.c"
 void*       _mi_page_malloc(mi_heap_t* heap, mi_page_t* page, size_t size) mi_attr_noexcept;  // called from `_mi_malloc_generic`
-void*       _mi_heap_malloc_zero(mi_heap_t* heap, size_t size, bool zero);
-void*       _mi_heap_realloc_zero(mi_heap_t* heap, void* p, size_t newsize, bool zero);
+void*       _mi_heap_malloc_zero(mi_heap_t* heap, size_t size, mi_alloc_init_t init);
+void*       _mi_heap_realloc_zero(mi_heap_t* heap, void* p, size_t newsize, mi_alloc_init_t init);
 mi_block_t* _mi_page_ptr_unalign(const mi_segment_t* segment, const mi_page_t* page, const void* p);
 bool        _mi_free_delayed_block(mi_block_t* block);
 void        _mi_block_zero_init(const mi_page_t* page, void* p, size_t size);

--- a/include/mimalloc-types.h
+++ b/include/mimalloc-types.h
@@ -167,6 +167,11 @@ typedef int32_t  mi_ssize_t;
 // Used as a special value to encode block sizes in 32 bits.
 #define MI_HUGE_BLOCK_SIZE   ((uint32_t)MI_HUGE_OBJ_SIZE_MAX)
 
+typedef enum mi_alloc_init_e {
+  MI_ALLOC_UNINIT = 0,    // uninitialized memory (debug mode: fill with MI_DEBUG_UNINIT)
+  MI_ALLOC_ZERO_INIT = 1  // zero-initialize memory
+} mi_alloc_init_t;
+
 
 // ------------------------------------------------------
 // Mimalloc pages contain allocated blocks

--- a/src/alloc-aligned.c
+++ b/src/alloc-aligned.c
@@ -15,7 +15,7 @@ terms of the MIT license. A copy of the license can be found in the file
 // ------------------------------------------------------
 
 // Fallback primitive aligned allocation -- split out for better codegen
-static mi_decl_noinline void* mi_heap_malloc_zero_aligned_at_fallback(mi_heap_t* const heap, const size_t size, const size_t alignment, const size_t offset, const mi_alloc_init_t init) mi_attr_noexcept
+static mi_decl_noinline void* mi_heap_malloc_init_aligned_at_fallback(mi_heap_t* const heap, const size_t size, const size_t alignment, const size_t offset, const mi_alloc_init_t init) mi_attr_noexcept
 {
   mi_assert_internal(size <= PTRDIFF_MAX);
   mi_assert_internal(alignment!=0 && _mi_is_power_of_two(alignment) && alignment <= MI_ALIGNMENT_MAX);
@@ -25,13 +25,13 @@ static mi_decl_noinline void* mi_heap_malloc_zero_aligned_at_fallback(mi_heap_t*
 
   // use regular allocation if it is guaranteed to fit the alignment constraints
   if (offset==0 && alignment<=padsize && padsize<=MI_MEDIUM_OBJ_SIZE_MAX && (padsize&align_mask)==0) {
-    void* p = _mi_heap_malloc_zero(heap, size, init);
+    void* p = _mi_heap_malloc_init(heap, size, init);
     mi_assert_internal(p == NULL || ((uintptr_t)p % alignment) == 0);
     return p;
   }
 
   // otherwise over-allocate
-  void* p = _mi_heap_malloc_zero(heap, size + alignment - 1, init);
+  void* p = _mi_heap_malloc_init(heap, size + alignment - 1, init);
   if (p == NULL) return NULL;
 
   // .. and align within the allocation
@@ -45,7 +45,7 @@ static mi_decl_noinline void* mi_heap_malloc_zero_aligned_at_fallback(mi_heap_t*
 }
 
 // Primitive aligned allocation
-static void* mi_heap_malloc_zero_aligned_at(mi_heap_t* const heap, const size_t size, const size_t alignment, const size_t offset, const mi_alloc_init_t init) mi_attr_noexcept
+static void* mi_heap_malloc_init_aligned_at(mi_heap_t* const heap, const size_t size, const size_t alignment, const size_t offset, const mi_alloc_init_t init) mi_attr_noexcept
 {
   // note: we don't require `size > offset`, we just guarantee that the address at offset is aligned regardless of the allocated size.
   mi_assert(alignment > 0);
@@ -87,7 +87,7 @@ static void* mi_heap_malloc_zero_aligned_at(mi_heap_t* const heap, const size_t 
     }
   }
   // fallback
-  return mi_heap_malloc_zero_aligned_at_fallback(heap, size, alignment, offset, init);
+  return mi_heap_malloc_init_aligned_at_fallback(heap, size, alignment, offset, init);
 }
 
 
@@ -96,7 +96,7 @@ static void* mi_heap_malloc_zero_aligned_at(mi_heap_t* const heap, const size_t 
 // ------------------------------------------------------
 
 mi_decl_restrict void* mi_heap_malloc_aligned_at(mi_heap_t* heap, size_t size, size_t alignment, size_t offset) mi_attr_noexcept {
-  return mi_heap_malloc_zero_aligned_at(heap, size, alignment, offset, MI_ALLOC_UNINIT);
+  return mi_heap_malloc_init_aligned_at(heap, size, alignment, offset, MI_ALLOC_UNINIT);
 }
 
 mi_decl_restrict void* mi_heap_malloc_aligned(mi_heap_t* heap, size_t size, size_t alignment) mi_attr_noexcept {
@@ -123,7 +123,7 @@ mi_decl_restrict void* mi_heap_malloc_aligned(mi_heap_t* heap, size_t size, size
 // ------------------------------------------------------
 
 mi_decl_restrict void* mi_heap_zalloc_aligned_at(mi_heap_t* heap, size_t size, size_t alignment, size_t offset) mi_attr_noexcept {
-  return mi_heap_malloc_zero_aligned_at(heap, size, alignment, offset, MI_ALLOC_ZERO_INIT);
+  return mi_heap_malloc_init_aligned_at(heap, size, alignment, offset, MI_ALLOC_ZERO_INIT);
 }
 
 mi_decl_restrict void* mi_heap_zalloc_aligned(mi_heap_t* heap, size_t size, size_t alignment) mi_attr_noexcept {
@@ -169,10 +169,10 @@ mi_decl_restrict void* mi_calloc_aligned(size_t count, size_t size, size_t align
 // Aligned re-allocation
 // ------------------------------------------------------
 
-static void* mi_heap_realloc_zero_aligned_at(mi_heap_t* heap, void* p, size_t newsize, size_t alignment, size_t offset, mi_alloc_init_t init) mi_attr_noexcept {
+static void* mi_heap_realloc_init_aligned_at(mi_heap_t* heap, void* p, size_t newsize, size_t alignment, size_t offset, mi_alloc_init_t init) mi_attr_noexcept {
   mi_assert(alignment > 0);
-  if (alignment <= sizeof(uintptr_t)) return _mi_heap_realloc_zero(heap,p,newsize,init);
-  if (p == NULL) return mi_heap_malloc_zero_aligned_at(heap,newsize,alignment,offset,init);
+  if (alignment <= sizeof(uintptr_t)) return _mi_heap_realloc_init(heap,p,newsize,init);
+  if (p == NULL) return mi_heap_malloc_init_aligned_at(heap,newsize,alignment,offset,init);
   size_t size = mi_usable_size(p);
   if (newsize <= size && newsize >= (size - (size / 2))
       && (((uintptr_t)p + offset) % alignment) == 0) {
@@ -200,27 +200,27 @@ static void* mi_heap_realloc_zero_aligned_at(mi_heap_t* heap, void* p, size_t ne
   }
 }
 
-static void* mi_heap_realloc_zero_aligned(mi_heap_t* heap, void* p, size_t newsize, size_t alignment, mi_alloc_init_t init) mi_attr_noexcept {
+static void* mi_heap_realloc_init_aligned(mi_heap_t* heap, void* p, size_t newsize, size_t alignment, mi_alloc_init_t init) mi_attr_noexcept {
   mi_assert(alignment > 0);
-  if (alignment <= sizeof(uintptr_t)) return _mi_heap_realloc_zero(heap,p,newsize,init);
+  if (alignment <= sizeof(uintptr_t)) return _mi_heap_realloc_init(heap,p,newsize,init);
   size_t offset = ((uintptr_t)p % alignment); // use offset of previous allocation (p can be NULL)
-  return mi_heap_realloc_zero_aligned_at(heap,p,newsize,alignment,offset,init);
+  return mi_heap_realloc_init_aligned_at(heap,p,newsize,alignment,offset,init);
 }
 
 void* mi_heap_realloc_aligned_at(mi_heap_t* heap, void* p, size_t newsize, size_t alignment, size_t offset) mi_attr_noexcept {
-  return mi_heap_realloc_zero_aligned_at(heap,p,newsize,alignment,offset,MI_ALLOC_UNINIT);
+  return mi_heap_realloc_init_aligned_at(heap,p,newsize,alignment,offset,MI_ALLOC_UNINIT);
 }
 
 void* mi_heap_realloc_aligned(mi_heap_t* heap, void* p, size_t newsize, size_t alignment) mi_attr_noexcept {
-  return mi_heap_realloc_zero_aligned(heap,p,newsize,alignment,MI_ALLOC_UNINIT);
+  return mi_heap_realloc_init_aligned(heap,p,newsize,alignment,MI_ALLOC_UNINIT);
 }
 
 void* mi_heap_rezalloc_aligned_at(mi_heap_t* heap, void* p, size_t newsize, size_t alignment, size_t offset) mi_attr_noexcept {
-  return mi_heap_realloc_zero_aligned_at(heap, p, newsize, alignment, offset, MI_ALLOC_ZERO_INIT);
+  return mi_heap_realloc_init_aligned_at(heap, p, newsize, alignment, offset, MI_ALLOC_ZERO_INIT);
 }
 
 void* mi_heap_rezalloc_aligned(mi_heap_t* heap, void* p, size_t newsize, size_t alignment) mi_attr_noexcept {
-  return mi_heap_realloc_zero_aligned(heap, p, newsize, alignment, MI_ALLOC_ZERO_INIT);
+  return mi_heap_realloc_init_aligned(heap, p, newsize, alignment, MI_ALLOC_ZERO_INIT);
 }
 
 void* mi_heap_recalloc_aligned_at(mi_heap_t* heap, void* p, size_t newcount, size_t size, size_t alignment, size_t offset) mi_attr_noexcept {

--- a/src/alloc-aligned.c
+++ b/src/alloc-aligned.c
@@ -83,6 +83,11 @@ static void* mi_heap_malloc_init_aligned_at(mi_heap_t* const heap, const size_t 
       mi_assert_internal(p != NULL);
       mi_assert_internal(((uintptr_t)p + offset) % alignment == 0);
       if (init == MI_ALLOC_ZERO_INIT) { _mi_block_zero_init(page, p, size); }
+      else if (init == MI_ALLOC_UNINIT) {
+      #if MI_DEBUG >= 2
+        _mi_debug_uninit_fill(p, size);
+      #endif
+      }
       return p;
     }
   }

--- a/test/test-api.c
+++ b/test/test-api.c
@@ -73,6 +73,11 @@ bool test_stl_allocator1(void);
 bool test_stl_allocator2(void);
 
 // ---------------------------------------------------------------------------
+// Helper functions
+// ---------------------------------------------------------------------------
+bool check_zero_init(uint8_t* p, size_t size);
+
+// ---------------------------------------------------------------------------
 // Main testing
 // ---------------------------------------------------------------------------
 int main(void) {
@@ -98,6 +103,144 @@ int main(void) {
   CHECK_BODY("calloc0",{
     result = (mi_usable_size(mi_calloc(0,1000)) <= 16);
   });
+
+  // ---------------------------------------------------
+  // Zeroing allocation
+  // ---------------------------------------------------
+  CHECK_BODY("zalloc-small", {
+    size_t zalloc_size = MI_SMALL_SIZE_MAX / 2;
+    uint8_t* p = (uint8_t*)mi_zalloc(zalloc_size);
+    result = check_zero_init(p, zalloc_size);
+    mi_free(p);
+  });
+  CHECK_BODY("zalloc-large", {
+    size_t zalloc_size = MI_SMALL_SIZE_MAX * 2;
+    uint8_t* p = (uint8_t*)mi_zalloc(zalloc_size);
+    result = check_zero_init(p, zalloc_size);
+    mi_free(p);
+  });
+  CHECK_BODY("zalloc_small", {
+    size_t zalloc_size = MI_SMALL_SIZE_MAX / 2;
+    uint8_t* p = (uint8_t*)mi_zalloc_small(zalloc_size);
+    result = check_zero_init(p, zalloc_size);
+    mi_free(p);
+  });
+
+  CHECK_BODY("calloc-small", {
+    size_t calloc_size = MI_SMALL_SIZE_MAX / 2;
+    uint8_t* p = (uint8_t*)mi_calloc(calloc_size, 1);
+    result = check_zero_init(p, calloc_size);
+    mi_free(p);
+  });
+  CHECK_BODY("calloc-large", {
+    size_t calloc_size = MI_SMALL_SIZE_MAX * 2;
+    uint8_t* p = (uint8_t*)mi_calloc(calloc_size, 1);
+    result = check_zero_init(p, calloc_size);
+    mi_free(p);
+  });
+
+  CHECK_BODY("rezalloc-small", {
+    size_t zalloc_size = MI_SMALL_SIZE_MAX / 2;
+    uint8_t* p = (uint8_t*)mi_zalloc(zalloc_size);
+    result = check_zero_init(p, zalloc_size);
+    zalloc_size *= 3;
+    p = (uint8_t*)mi_rezalloc(p, zalloc_size);
+    result &= check_zero_init(p, zalloc_size);
+    mi_free(p);
+  });
+  CHECK_BODY("rezalloc-large", {
+    size_t zalloc_size = MI_SMALL_SIZE_MAX * 2;
+    uint8_t* p = (uint8_t*)mi_zalloc(zalloc_size);
+    result = check_zero_init(p, zalloc_size);
+    zalloc_size *= 3;
+    p = (uint8_t*)mi_rezalloc(p, zalloc_size);
+    result &= check_zero_init(p, zalloc_size);
+    mi_free(p);
+  });
+
+  CHECK_BODY("recalloc-small", {
+    size_t calloc_size = MI_SMALL_SIZE_MAX / 2;
+    uint8_t* p = (uint8_t*)mi_calloc(calloc_size, 1);
+    result = check_zero_init(p, calloc_size);
+    calloc_size *= 3;
+    p = (uint8_t*)mi_recalloc(p, calloc_size, 1);
+    result &= check_zero_init(p, calloc_size);
+    mi_free(p);
+  });
+  CHECK_BODY("recalloc-large", {
+    size_t calloc_size = MI_SMALL_SIZE_MAX * 2;
+    uint8_t* p = (uint8_t*)mi_calloc(calloc_size, 1);
+    result = check_zero_init(p, calloc_size);
+    calloc_size *= 3;
+    p = (uint8_t*)mi_recalloc(p, calloc_size, 1);
+    result &= check_zero_init(p, calloc_size);
+    mi_free(p);
+  });
+
+  CHECK_BODY("zalloc_aligned-small", {
+    size_t zalloc_size = MI_SMALL_SIZE_MAX / 2;
+    uint8_t* p = (uint8_t*)mi_zalloc_aligned(zalloc_size, MI_MAX_ALIGN_SIZE * 2);
+    result = check_zero_init(p, zalloc_size);
+    mi_free(p);
+  });
+  CHECK_BODY("zalloc_aligned-large", {
+    size_t zalloc_size = MI_SMALL_SIZE_MAX * 2;
+    uint8_t* p = (uint8_t*)mi_zalloc_aligned(zalloc_size, MI_MAX_ALIGN_SIZE * 2);
+    result = check_zero_init(p, zalloc_size);
+    mi_free(p);
+  });
+
+  CHECK_BODY("calloc_aligned-small", {
+    size_t calloc_size = MI_SMALL_SIZE_MAX / 2;
+    uint8_t* p = (uint8_t*)mi_calloc_aligned(calloc_size, 1, MI_MAX_ALIGN_SIZE * 2);
+    result = check_zero_init(p, calloc_size);
+    mi_free(p);
+  });
+  CHECK_BODY("calloc_aligned-large", {
+    size_t calloc_size = MI_SMALL_SIZE_MAX * 2;
+    uint8_t* p = (uint8_t*)mi_calloc_aligned(calloc_size, 1, MI_MAX_ALIGN_SIZE * 2);
+    result = check_zero_init(p, calloc_size);
+    mi_free(p);
+  });
+
+  CHECK_BODY("rezalloc_aligned-small", {
+    size_t zalloc_size = MI_SMALL_SIZE_MAX / 2;
+    uint8_t* p = (uint8_t*)mi_zalloc_aligned(zalloc_size, MI_MAX_ALIGN_SIZE * 2);
+    result = check_zero_init(p, zalloc_size);
+    zalloc_size *= 3;
+    p = (uint8_t*)mi_rezalloc_aligned(p, zalloc_size, MI_MAX_ALIGN_SIZE * 2);
+    result &= check_zero_init(p, zalloc_size);
+    mi_free(p);
+  });
+  CHECK_BODY("rezalloc_aligned-large", {
+    size_t zalloc_size = MI_SMALL_SIZE_MAX * 2;
+    uint8_t* p = (uint8_t*)mi_zalloc_aligned(zalloc_size, MI_MAX_ALIGN_SIZE * 2);
+    result = check_zero_init(p, zalloc_size);
+    zalloc_size *= 3;
+    p = (uint8_t*)mi_rezalloc_aligned(p, zalloc_size, MI_MAX_ALIGN_SIZE * 2);
+    result &= check_zero_init(p, zalloc_size);
+    mi_free(p);
+  });
+
+  CHECK_BODY("recalloc_aligned-small", {
+    size_t calloc_size = MI_SMALL_SIZE_MAX / 2;
+    uint8_t* p = (uint8_t*)mi_calloc_aligned(calloc_size, 1, MI_MAX_ALIGN_SIZE * 2);
+    result = check_zero_init(p, calloc_size);
+    calloc_size *= 3;
+    p = (uint8_t*)mi_recalloc_aligned(p, calloc_size, 1, MI_MAX_ALIGN_SIZE * 2);
+    result &= check_zero_init(p, calloc_size);
+    mi_free(p);
+  });
+  CHECK_BODY("recalloc_aligned-large", {
+    size_t calloc_size = MI_SMALL_SIZE_MAX * 2;
+    uint8_t* p = (uint8_t*)mi_calloc_aligned(calloc_size, 1, MI_MAX_ALIGN_SIZE * 2);
+    result = check_zero_init(p, calloc_size);
+    calloc_size *= 3;
+    p = (uint8_t*)mi_recalloc_aligned(p, calloc_size, 1, MI_MAX_ALIGN_SIZE * 2);
+    result &= check_zero_init(p, calloc_size);
+    mi_free(p);
+  });
+
 
   // ---------------------------------------------------
   // Extended
@@ -271,4 +414,18 @@ bool test_stl_allocator2() {
 #else
   return true;
 #endif
+}
+
+// ---------------------------------------------------------------------------
+// Helper functions
+// ---------------------------------------------------------------------------
+
+bool check_zero_init(uint8_t* p, size_t size) {
+  if(!p)
+    return false;
+  bool result = true;
+  for (size_t i = 0; i < size; ++i) {
+    result &= p[i] == 0;
+  }
+  return result;
 }


### PR DESCRIPTION
Hi,
this is an attempt to address #501.

But rather than "pass an `bool zero_data` argument to `_mi_page_malloc`" I went with another approach: doing the "uninit fill" further "up" in the logic, specifically where zero initialization is typically done as well.

Noteworthy:
* Some reorganization of the allocation functions, to perform either zero-initialization or "uninit fill", but not necessarily both.
* I replaced `bool zero` with an enum. I like to think this improves readability.
* I added a bunch of tests to verify zeroing happens when it should, and some more tests to verify filling happens in debug mode.

* What do you think about the general approach?
* Do the various function qualifiers look sensible?
* What's your opinion on the tests? I'm thinking there are so many new ones, a new test program may be in order...

Looking forward to your feedback :)