### PR TITLE
cmake: export mimalloc-static as well

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,6 +330,7 @@ if (MI_BUILD_STATIC)
   endif()
 
   install(TARGETS mimalloc-static EXPORT mimalloc DESTINATION ${mi_install_libdir} LIBRARY)
+  install(EXPORT mimalloc DESTINATION ${mi_install_cmakedir})
 endif()
 
 # install include files


### PR DESCRIPTION
Otherwise a static only build would not be usable as cmake package
(as mimalloc.cmake wouldn't be generated).