### PR TITLE
Allow overrides of MI_DEBUG memory constants

### DIFF
--- a/include/mimalloc-types.h
+++ b/include/mimalloc-types.h
@@ -393,9 +393,15 @@ struct mi_heap_s {
 // Debug
 // ------------------------------------------------------
 
+#if !defined(MI_DEBUG_UNINIT)
 #define MI_DEBUG_UNINIT     (0xD0)
+#endif
+#if !defined(MI_DEBUG_FREED)
 #define MI_DEBUG_FREED      (0xDF)
+#endif
+#if !defined(MI_DEBUG_PADDING)
 #define MI_DEBUG_PADDING    (0xDE)
+#endif
 
 #if (MI_DEBUG)
 // use our own assertion to print without memory allocation


### PR DESCRIPTION
CPython and Windows CRT debug builds use different values for uninit,
freed, and padding bytes. Make ``MI_DEBUG_*`` constants conditional to
allow embedders to override the constants.

Windows dbgheap:

```
_bNoMansLandFill = 0xFD
_bDeadLandFill   = 0xDD
_bCleanLandFill  = 0xCD
```

Python memory debug

```
PYMEM_CLEANBYTE      0xCD
PYMEM_DEADBYTE       0xDD
PYMEM_FORBIDDENBYTE  0xFD
```

Signed-off-by: Christian Heimes <christian@python.org>