### PR TITLE
fixes for compile errors on macOS 10.13 with XCode 10.1

### DIFF
--- a/src/alloc-override-osx.c
+++ b/src/alloc-override-osx.c
@@ -110,11 +110,13 @@ static void zone_free_definite_size(malloc_zone_t* zone, void* p, size_t size) {
   zone_free(zone,p);
 }
 
+#if defined(MAC_OS_X_VERSION_10_14) && \
+    MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_14
 static boolean_t zone_claimed_address(malloc_zone_t* zone, void* p) {
   MI_UNUSED(zone);
   return mi_is_in_heap_region(p);
 }
-
+#endif
 
 /* ------------------------------------------------------
    Introspection members
@@ -211,12 +213,14 @@ static malloc_zone_t mi_malloc_zone = {
   .batch_malloc = &zone_batch_malloc,
   .batch_free = &zone_batch_free,
   .introspect = &mi_introspect,  
-#if defined(MAC_OS_X_VERSION_10_6) && MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_6
+#if defined(MAC_OS_X_VERSION_10_6) && \
+    MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_6
   // switch to version 9+ on OSX 10.6 to support memalign.
   .memalign = &zone_memalign,
   .free_definite_size = &zone_free_definite_size,
   .pressure_relief = &zone_pressure_relief,
-  #if defined(MAC_OS_X_VERSION_10_7) && MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_7
+  #if defined(MAC_OS_X_VERSION_10_14) && \
+    MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_14
   .claimed_address = &zone_claimed_address,
   .version = 10
   #else

--- a/src/alloc-override.c
+++ b/src/alloc-override.c
@@ -77,7 +77,7 @@ typedef struct mi_nothrow_s { int _tag; } mi_nothrow_t;
     MI_INTERPOSE_MI(valloc),
     MI_INTERPOSE_MI(malloc_size),
     MI_INTERPOSE_MI(malloc_good_size),
-    MI_INTERPOSE_MI(aligned_alloc),
+    //MI_INTERPOSE_MI(aligned_alloc),
     #ifdef MI_OSX_ZONE
     // we interpose malloc_default_zone in alloc-override-osx.c so we can use mi_free safely
     MI_INTERPOSE_MI(free),

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -486,7 +486,7 @@ void mi_free(void* p) mi_attr_noexcept
   mi_page_t* const page = _mi_segment_page_of(segment, p);
   mi_block_t* const block = (mi_block_t*)p;
 
-  if (mi_likely(tid == mi_atomic_load_relaxed(&segment->thread_id) && page->flags.full_aligned == 0)) {  // the thread id matches and it is not a full page, nor has aligned blocks
+  if (mi_likely(tid == mi_atomic_load_relaxed((_Atomic(mi_threadid_t)*)&segment->thread_id) && page->flags.full_aligned == 0)) {  // the thread id matches and it is not a full page, nor has aligned blocks
     // local, and not full or aligned
     if (mi_unlikely(mi_check_is_double_free(page,block))) return;
     mi_check_padding(page, block);


### PR DESCRIPTION
some changes that were required to compile mimalloc on macOS 10.13:

- fix compiler error due to const argument to `mi_atomic_load_relaxed`
  - seems the address to `atomic_load_relaxed` should be const so perhaps this is a bug in the XCode 10.1 `<stdatomic.h>` header, nevertheless, a change is needed to get mimalloc to compile with this version of the XCode C library headers. an alternative fix may be to make the segment pointer non-const.
  - reference: https://en.cppreference.com/w/c/atomic/atomic_load
- fix compiler error `claimed_address` is not present in `malloc_zone_t` until macOS 10.14
  - searched through the `libmalloc` versions to verify this field first appears in macOS 10.14.
- fix compiler error `aligned_alloc` is not present in C on any version of macOS
  - the function appears in `XcodeDefault.xctoolchain/usr/include/c++/v1/stdlib.h` but not in any of the SDK `/usr/include/stdlib.h` headers, so one presumes it is only available in C++ on macOS.

```
$ clang --version
Apple LLVM version 10.0.0 (clang-1000.11.45.5)
Target: x86_64-apple-darwin17.7.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```