### PR TITLE
histogram: add pow2 allocation stats via MIMALLOC_SHOW_HISTOGRAM=1

### DIFF
--- a/include/mimalloc-internal.h
+++ b/include/mimalloc-internal.h
@@ -126,6 +126,8 @@ void       _mi_heap_set_default_direct(mi_heap_t* heap);
 
 // "stats.c"
 void       _mi_stats_done(mi_stats_t* stats);
+void       _mi_histogram_log(size_t size);
+void       _mi_histogram_print(mi_output_fun* out);
 
 mi_msecs_t  _mi_clock_now(void);
 mi_msecs_t  _mi_clock_end(mi_msecs_t start);

--- a/include/mimalloc.h
+++ b/include/mimalloc.h
@@ -303,6 +303,7 @@ typedef enum mi_option_e {
   // stable options
   mi_option_show_errors,
   mi_option_show_stats,
+  mi_option_show_histogram,
   mi_option_verbose,
   // the following options are experimental
   mi_option_eager_commit,

--- a/src/init.c
+++ b/src/init.c
@@ -543,6 +543,9 @@ static void mi_process_done(void) {
   if (mi_option_is_enabled(mi_option_show_stats) || mi_option_is_enabled(mi_option_verbose)) {
     mi_stats_print(NULL);
   }
+  if (mi_option_is_enabled(mi_option_show_histogram)) {
+    _mi_histogram_print(NULL);
+  }
   mi_allocator_done();  
   _mi_verbose_message("process done: 0x%zx\n", _mi_heap_main.thread_id);
   os_preloading = true; // don't call the C runtime anymore

--- a/src/options.c
+++ b/src/options.c
@@ -63,6 +63,7 @@ static mi_option_desc_t options[_mi_option_last] =
   { 0, UNINIT, MI_OPTION(show_errors) },
 #endif
   { 0, UNINIT, MI_OPTION(show_stats) },
+  { 0, UNINIT, MI_OPTION(show_histogram) },
   { 0, UNINIT, MI_OPTION(verbose) },
 
   // the following options are experimental and not all combinations make sense.


### PR DESCRIPTION
I do not intend this pull to be merged, but am surfacing the feature just in case anyone finds it useful. It is a bit easier to read if one is trying to assess allocation sizes with a power of two granularity. It is currently guarded behind `#ifdef MI_STAT>1` but `#if MI_DEBUG>0` might be more appropriate. It currently adds an atomic_increment to counters in a shared histogram array. It could be changed to use thread-local arrays that are merged at program termination.