### PR TITLE
Fix strict function prototype warnings

### DIFF
--- a/src/os.c
+++ b/src/os.c
@@ -107,7 +107,7 @@ bool _mi_os_has_overcommit(void) {
 }
 
 // OS (small) page size
-size_t _mi_os_page_size() {
+size_t _mi_os_page_size(void) {
   return os_page_size;
 }
 
@@ -159,7 +159,7 @@ static PGetCurrentProcessorNumberEx pGetCurrentProcessorNumberEx = NULL;
 static PGetNumaProcessorNodeEx      pGetNumaProcessorNodeEx = NULL;
 static PGetNumaNodeProcessorMaskEx  pGetNumaNodeProcessorMaskEx = NULL;
 
-static bool mi_win_enable_large_os_pages()
+static bool mi_win_enable_large_os_pages(void)
 {
   if (large_os_page_size > 0) return true;
 
@@ -230,7 +230,7 @@ void _mi_os_init(void)
   }
 }
 #elif defined(__wasi__)
-void _mi_os_init() {
+void _mi_os_init(void) {
   os_overcommit = false;
   os_page_size = 64*MI_KiB; // WebAssembly has a fixed page size: 64KiB
   os_alloc_granularity = 16;
@@ -261,7 +261,7 @@ static void os_detect_overcommit(void) {
 #endif
 }
 
-void _mi_os_init() {
+void _mi_os_init(void) {
   // get the page size
   long result = sysconf(_SC_PAGESIZE);
   if (result > 0) {
@@ -1302,7 +1302,7 @@ void _mi_os_free_huge_pages(void* p, size_t size, mi_stats_t* stats) {
 Support NUMA aware allocation
 -----------------------------------------------------------------------------*/
 #ifdef _WIN32  
-static size_t mi_os_numa_nodex() {
+static size_t mi_os_numa_nodex(void) {
   USHORT numa_node = 0;
   if (pGetCurrentProcessorNumberEx != NULL && pGetNumaProcessorNodeEx != NULL) {
     // Extended API is supported


### PR DESCRIPTION
Fix warning: function declaration isn't a prototype [-Wstrict-prototypes]
In C int foo() and int foo(void) are different functions.