### PR TITLE
Fix compatibility with GNU libstdc++ < 9

### DIFF
--- a/include/mimalloc-new-delete.h
+++ b/include/mimalloc-new-delete.h
@@ -25,6 +25,9 @@ terms of the MIT license. A copy of the license can be found in the file
   void operator delete(void* p) noexcept              { mi_free(p); };
   void operator delete[](void* p) noexcept            { mi_free(p); };
 
+  void operator delete  (void* p, const std::nothrow_t&) noexcept { mi_free(p); }
+  void operator delete[](void* p, const std::nothrow_t&) noexcept { mi_free(p); }
+
   void* operator new(std::size_t n) noexcept(false)   { return mi_new(n); }
   void* operator new[](std::size_t n) noexcept(false) { return mi_new(n); }
 


### PR DESCRIPTION
So far, mimalloc does not override the `nothrow` variants of the `delete` operator because it assumes that their implementation in the C++ standard library redirects to the default `delete` operators. This is not the case for GNU libstdc++ < 9, where `std::free()` is called directly.

This issue might be the cause for the crashes reported in #261.

Upstream bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68210

This commit ensures that the `nothrow` `delete` operators are properly overridden by mimalloc.