### PR TITLE
Support `-fno-exceptions` when building with C++ support

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -803,7 +803,11 @@ static bool mi_try_new_handler(bool nothrow) {
   if (h==NULL) {
     _mi_error_message(ENOMEM, "out of memory in 'new'");      
     if (!nothrow) {
+#ifdef __EXCEPTIONS
       throw std::bad_alloc();
+#else 
+      abort();
+#endif
     }
     return false;
   }


### PR DESCRIPTION
Using `abort` to match what is done elsewhere

This reduces the number of symbols imported which can slightly improve startup time

Before:
```
❯ nm -g (which bun) | wc -c
19707
```

After:
```
❯ nm -g (which bun) | wc -c
19430
```

