### PR TITLE
Fixing build for windows arm64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -305,18 +305,21 @@ if(MI_BUILD_SHARED)
       $<INSTALL_INTERFACE:${mi_install_incdir}>
   )
   if(WIN32)
-    # On windows copy the mimalloc redirection dll too.
-    if(CMAKE_SIZEOF_VOID_P EQUAL 4)
-      set(MIMALLOC_REDIRECT_SUFFIX "32")
-    else()
-      set(MIMALLOC_REDIRECT_SUFFIX "")
-    endif()
+    # Until the redirect lib has a version for arm don't try to copy it
+    if(NOT MSVC_C_ARCHITECTURE_ID MATCHES "ARM")
+      # On windows copy the mimalloc redirection dll too.
+      if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+        set(MIMALLOC_REDIRECT_SUFFIX "32")
+      else()
+        set(MIMALLOC_REDIRECT_SUFFIX "")
+      endif()
 
-    target_link_libraries(mimalloc PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/bin/mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.lib)
-    add_custom_command(TARGET mimalloc POST_BUILD
-      COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_CURRENT_SOURCE_DIR}/bin/mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.dll" $<TARGET_FILE_DIR:mimalloc>
-      COMMENT "Copy mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.dll to output directory")
-    install(FILES "$<TARGET_FILE_DIR:mimalloc>/mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.dll" DESTINATION ${mi_install_libdir})
+      target_link_libraries(mimalloc PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/bin/mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.lib)
+      add_custom_command(TARGET mimalloc POST_BUILD
+        COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_CURRENT_SOURCE_DIR}/bin/mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.dll" $<TARGET_FILE_DIR:mimalloc>
+        COMMENT "Copy mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.dll to output directory")
+      install(FILES "$<TARGET_FILE_DIR:mimalloc>/mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.dll" DESTINATION ${mi_install_libdir})
+    endif()
   endif()
 
   install(TARGETS mimalloc EXPORT mimalloc DESTINATION ${mi_install_libdir} LIBRARY)  

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,6 +186,8 @@ if(MI_USE_CXX)
 endif()
 
 if(NOT MI_DISABLE_REDIRECT)
+  # When compiling for windows on arm the mimalloc-redirect library is not available
+  # as it has not been pre-compiled and the source is not yet available.
   if(MSVC AND MSVC_C_ARCHITECTURE_ID MATCHES "ARM")
     set(MI_DISABLE_REDIRECT ON)
     message(WARNING "Disabling redirection lib is required on ARM (MI_DISABLE_REDIRECT=ON)")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ option(MI_BUILD_TESTS       "Build test executables" ON)
 option(MI_DEBUG_TSAN        "Build with thread sanitizer (needs clang)" OFF)
 option(MI_DEBUG_UBSAN       "Build with undefined-behavior sanitizer (needs clang++)" OFF)
 option(MI_SKIP_COLLECT_ON_EXIT, "Skip collecting memory on program exit" OFF)
+option(MI_DISABLE_REDIRECT  "Do not use mimalloc-redirect on Windows (for shared libraries)" OFF)
 
 # deprecated options
 option(MI_CHECK_FULL        "Use full internal invariant checking in DEBUG mode (deprecated, use MI_DEBUG_FULL instead)" OFF)
@@ -184,6 +185,22 @@ if(MI_USE_CXX)
   endif()
 endif()
 
+if(NOT MI_DISABLE_REDIRECT)
+  if(MSVC AND MSVC_C_ARCHITECTURE_ID MATCHES "ARM")
+    set(MI_DISABLE_REDIRECT ON)
+    message(WARNING "Disabling redirection lib is required on ARM (MI_DISABLE_REDIRECT=ON)")
+  endif()
+endif()
+
+if (MI_DISABLE_REDIRECT)
+  if (NOT WIN32 OR NOT MI_SHARED_LIB)
+    message(WARNING "Disabling redirect only affects shared libraries on windows")
+  endif()
+
+  message(STATUS "Disabled mimalloc-redirect (MI_DISABLE_REDIRECT=ON)")
+  list(APPEND mi_defines MI_DISABLE_REDIRECT)
+endif()
+
 # Compiler flags
 if(CMAKE_C_COMPILER_ID MATCHES "AppleClang|Clang|GNU")
   list(APPEND mi_cflags -Wall -Wextra -Wno-unknown-pragmas -fvisibility=hidden)
@@ -304,15 +321,13 @@ if(MI_BUILD_SHARED)
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
       $<INSTALL_INTERFACE:${mi_install_incdir}>
   )
-  if(WIN32)
-    # Until the redirect lib has a version for arm don't try to copy it
-    if(NOT MSVC_C_ARCHITECTURE_ID MATCHES "ARM")
-      # On windows copy the mimalloc redirection dll too.
-      if(CMAKE_SIZEOF_VOID_P EQUAL 4)
-        set(MIMALLOC_REDIRECT_SUFFIX "32")
-      else()
-        set(MIMALLOC_REDIRECT_SUFFIX "")
-      endif()
+  if(WIN32 AND NOT MI_DISABLE_REDIRECT)
+    # On windows copy the mimalloc redirection dll too.
+    if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+      set(MIMALLOC_REDIRECT_SUFFIX "32")
+    else()
+      set(MIMALLOC_REDIRECT_SUFFIX "")
+    endif()
 
       target_link_libraries(mimalloc PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/bin/mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.lib)
       add_custom_command(TARGET mimalloc POST_BUILD

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -329,12 +329,11 @@ if(MI_BUILD_SHARED)
       set(MIMALLOC_REDIRECT_SUFFIX "")
     endif()
 
-      target_link_libraries(mimalloc PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/bin/mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.lib)
-      add_custom_command(TARGET mimalloc POST_BUILD
-        COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_CURRENT_SOURCE_DIR}/bin/mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.dll" $<TARGET_FILE_DIR:mimalloc>
-        COMMENT "Copy mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.dll to output directory")
-      install(FILES "$<TARGET_FILE_DIR:mimalloc>/mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.dll" DESTINATION ${mi_install_libdir})
-    endif()
+    target_link_libraries(mimalloc PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/bin/mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.lib)
+    add_custom_command(TARGET mimalloc POST_BUILD
+      COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_CURRENT_SOURCE_DIR}/bin/mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.dll" $<TARGET_FILE_DIR:mimalloc>
+      COMMENT "Copy mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.dll to output directory")
+    install(FILES "$<TARGET_FILE_DIR:mimalloc>/mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.dll" DESTINATION ${mi_install_libdir})
   endif()
 
   install(TARGETS mimalloc EXPORT mimalloc DESTINATION ${mi_install_libdir} LIBRARY)  

--- a/src/init.c
+++ b/src/init.c
@@ -490,7 +490,7 @@ mi_decl_nodiscard bool mi_is_redirected(void) mi_attr_noexcept {
 }
 
 // Communicate with the redirection module on Windows
-#if defined(_WIN32) && defined(MI_SHARED_LIB)
+#if defined(_WIN32) && defined(MI_SHARED_LIB) && !(defined(_M_ARM) || defined(_M_ARM64))
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/init.c
+++ b/src/init.c
@@ -490,7 +490,7 @@ mi_decl_nodiscard bool mi_is_redirected(void) mi_attr_noexcept {
 }
 
 // Communicate with the redirection module on Windows
-#if defined(_WIN32) && defined(MI_SHARED_LIB) && !(defined(_M_ARM) || defined(_M_ARM64))
+#if defined(_WIN32) && defined(MI_SHARED_LIB) && !defined(MI_DISABLE_REDIRECT)
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
I wanted to get the mimalloc port on vcpkg to work on arm64 for android, ios and macos as well as windows. After a creating a PR here to modify the vcpkg port https://github.com/microsoft/vcpkg/pull/25265 I realized that arm64 windows was broken, so here I present a fix. Though this raises some questions for me here about how best to go about this. Is the source to `mimalloc-redirect` available anywhere? Are there more complications in an arm64 build of mimalloc that I'm missing here? Or would it just be better to just skip out on arm64-windows for vcpkg for now?