### PR TITLE
Add option to disable redirect

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ option(MI_BUILD_TESTS       "Build test executables" ON)
 option(MI_DEBUG_TSAN        "Build with thread sanitizer (needs clang)" OFF)
 option(MI_DEBUG_UBSAN       "Build with undefined-behavior sanitizer (needs clang++)" OFF)
 option(MI_SKIP_COLLECT_ON_EXIT, "Skip collecting memory on program exit" OFF)
+option(MI_DISABLE_REDIRECT  "Do not use mimalloc-redirect on Windows (for shared libraries)" OFF)
 
 # deprecated options
 option(MI_CHECK_FULL        "Use full internal invariant checking in DEBUG mode (deprecated, use MI_DEBUG_FULL instead)" OFF)
@@ -184,6 +185,14 @@ if(MI_USE_CXX)
   endif()
 endif()
 
+if (MI_DISABLE_REDIRECT)
+  if (NOT WIN32 OR NOT MI_SHARED_LIB)
+    message(WARNING "Disabling redirect only affects shared libraries on windows")
+  endif()
+  message(STATUS "Disabled mimalloc-redirect (MI_DISABLE_REDIRECT=ON)")
+  list(APPEND mi_defines MI_DISABLE_REDIRECT)
+endif()
+
 # Compiler flags
 if(CMAKE_C_COMPILER_ID MATCHES "AppleClang|Clang|GNU")
   list(APPEND mi_cflags -Wall -Wextra -Wno-unknown-pragmas -fvisibility=hidden)
@@ -304,7 +313,7 @@ if(MI_BUILD_SHARED)
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
       $<INSTALL_INTERFACE:${mi_install_incdir}>
   )
-  if(WIN32)
+  if(WIN32 AND NOT MI_DISABLE_REDIRECT)
     # On windows copy the mimalloc redirection dll too.
     if(CMAKE_SIZEOF_VOID_P EQUAL 4)
       set(MIMALLOC_REDIRECT_SUFFIX "32")

--- a/src/init.c
+++ b/src/init.c
@@ -490,7 +490,7 @@ mi_decl_nodiscard bool mi_is_redirected(void) mi_attr_noexcept {
 }
 
 // Communicate with the redirection module on Windows
-#if defined(_WIN32) && defined(MI_SHARED_LIB)
+#if defined(_WIN32) && defined(MI_SHARED_LIB) && !defined(MI_DISABLE_REDIRECT)
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
I work on a project where I only wanted to replace the allocator in a single dll. In this case the allocations will not cross the DLL boundaries. Since this DLL is loaded late, I cannot rely on `mimalloc-redirect.dll`. This patch introduces a CMake option to disable redirect when we compile mimalloc on windows with shared libraries on.