### PR TITLE
Support compiling with alternative calling conventions

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -475,7 +475,7 @@ void _mi_heap_set_default_direct(mi_heap_t* heap)  {
 // --------------------------------------------------------
 // Run functions on process init/done, and thread init/done
 // --------------------------------------------------------
-static void mi_process_done(void);
+static void mi_cdecl mi_process_done(void);
 
 static bool os_preloading = true;    // true until this module is initialized
 static bool mi_redirected = false;   // true if malloc redirects to mi_malloc
@@ -506,8 +506,8 @@ mi_decl_export void _mi_redirect_entry(DWORD reason) {
     mi_thread_done();
   }
 }
-__declspec(dllimport) bool mi_allocator_init(const char** message);
-__declspec(dllimport) void mi_allocator_done(void);
+__declspec(dllimport) bool mi_cdecl mi_allocator_init(const char** message);
+__declspec(dllimport) void mi_cdecl mi_allocator_done(void);
 #ifdef __cplusplus
 }
 #endif
@@ -606,7 +606,7 @@ void mi_process_init(void) mi_attr_noexcept {
 }
 
 // Called when the process is done (through `at_exit`)
-static void mi_process_done(void) {
+static void mi_cdecl mi_process_done(void) {
   // only shutdown if we were initialized
   if (!_mi_process_is_initialized) return;
   // ensure we are called once

--- a/src/options.c
+++ b/src/options.c
@@ -170,7 +170,7 @@ void mi_option_disable(mi_option_t option) {
 }
 
 
-static void mi_out_stderr(const char* msg, void* arg) {
+static void mi_cdecl mi_out_stderr(const char* msg, void* arg) {
   MI_UNUSED(arg);
   if (msg == NULL) return;
   #ifdef _WIN32
@@ -203,7 +203,7 @@ static void mi_out_stderr(const char* msg, void* arg) {
 static char out_buf[MI_MAX_DELAY_OUTPUT+1];
 static _Atomic(size_t) out_len;
 
-static void mi_out_buf(const char* msg, void* arg) {
+static void mi_cdecl mi_out_buf(const char* msg, void* arg) {
   MI_UNUSED(arg);
   if (msg==NULL) return;
   if (mi_atomic_load_relaxed(&out_len)>=MI_MAX_DELAY_OUTPUT) return;
@@ -235,7 +235,7 @@ static void mi_out_buf_flush(mi_output_fun* out, bool no_more_buf, void* arg) {
 
 // Once this module is loaded, switch to this routine
 // which outputs to stderr and the delayed output buffer.
-static void mi_out_buf_stderr(const char* msg, void* arg) {
+static void mi_cdecl mi_out_buf_stderr(const char* msg, void* arg) {
   mi_out_stderr(msg,arg);
   mi_out_buf(msg,arg);
 }

--- a/src/stats.c
+++ b/src/stats.c
@@ -267,7 +267,7 @@ static void mi_buffered_flush(buffered_t* buf) {
   buf->used = 0;
 }
 
-static void mi_buffered_out(const char* msg, void* arg) {
+static void mi_cdecl mi_buffered_out(const char* msg, void* arg) {
   buffered_t* buf = (buffered_t*)arg;
   if (msg==NULL || buf==NULL) return;
   for (const char* src = msg; *src != 0; src++) {


### PR DESCRIPTION
Trying to compile mimalloc with an alternative calling convention (e.g. using `/Gz` for stdcall) will result in compilation errors:
```
D:\mimalloc\src\stats.c(293,40): error C2440: 'initializing': cannot convert from 'void (__stdcall *)(const char *,void *)' to 'mi_output_fun (__cdecl *)' [D:\mimalloc\build32-noredirect\mimalloc-obj.vcxproj]
D:\mimalloc\src\stats.c(293,22): message : This conversion requires a reinterpret_cast, a C-style cast or parenthesized function-style cast [D:\mimalloc\build32-noredirect\mimalloc-obj.vcxproj]
D:\mimalloc\src\init.c(533,26): error C2664: 'int atexit(void (__cdecl *)(void))': cannot convert argument 1 from 'void (__stdcall *)(void)' to 'void (__cdecl *)(void)' [D:\mimalloc\build32-noredirect\mimalloc
-obj.vcxproj]
D:\mimalloc\src\init.c(533,10): message : This conversion requires a reinterpret_cast, a C-style cast or parenthesized function-style cast [D:\mimalloc\build32-noredirect\mimalloc-obj.vcxproj]
predefined C++ types (compiler internal)(109,24): message : see declaration of 'atexit' [D:\mimalloc\build32-noredirect\mimalloc-obj.vcxproj]
D:\mimalloc\src\options.c(257,42): error C2446: ':': no conversion from 'mi_output_fun (__cdecl *)' to 'void (__stdcall *)(const char *,void *)' [D:\mimalloc\build32-noredirect\mimalloc-obj.vcxproj]
D:\mimalloc\src\options.c(257,39): message : This conversion requires a reinterpret_cast, a C-style cast or parenthesized function-style cast [D:\mimalloc\build32-noredirect\mimalloc-obj.vcxproj]
D:\mimalloc\src\options.c(261,55): error C2446: ':': no conversion from 'mi_output_fun (__cdecl *)' to 'void (__stdcall *)(const char *,void *)' [D:\mimalloc\build32-noredirect\mimalloc-obj.vcxproj]
D:\mimalloc\src\options.c(261,52): message : This conversion requires a reinterpret_cast, a C-style cast or parenthesized function-style cast [D:\mimalloc\build32-noredirect\mimalloc-obj.vcxproj]
D:\mimalloc\src\options.c(269,47): error C2664: 'void mi_out_buf_flush(mi_output_fun (__cdecl *),bool,void *)': cannot convert argument 1 from 'void (__stdcall *)(const char *,void *)' to 'mi_output_fun (__cde
cl *)' [D:\mimalloc\build32-noredirect\mimalloc-obj.vcxproj]
D:\mimalloc\src\options.c(269,20): message : This conversion requires a reinterpret_cast, a C-style cast or parenthesized function-style cast [D:\mimalloc\build32-noredirect\mimalloc-obj.vcxproj]
D:\mimalloc\src\options.c(222,13): message : see declaration of 'mi_out_buf_flush' [D:\mimalloc\build32-noredirect\mimalloc-obj.vcxproj]
D:\mimalloc\src\options.c(270,38): error C2440: '=': cannot convert from 'void (__stdcall *)(const char *,void *)' to 'mi_output_fun (__cdecl *volatile )' [D:\mimalloc\build32-noredirect\mimalloc-obj.vcxproj]
D:\mimalloc\src\options.c(270,20): message : This conversion requires a reinterpret_cast, a C-style cast or parenthesized function-style cast [D:\mimalloc\build32-noredirect\mimalloc-obj.vcxproj]
```

This PR adds `mi_cdecl` to a bunch of functions to make sure the code can be compiled after changing the default calling convention.