### PR TITLE
cmake: add pkg-config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,18 +217,22 @@ endif()
 # extra needed libraries
 if(WIN32)
   list(APPEND mi_libraries psapi shell32 user32 advapi32 bcrypt)
+  set(pc_libraries "-lpsapi -lshell32 -luser32 -ladvapi32 -lbcrypt")
 else()
   find_library(MI_LIBPTHREAD pthread)
   if (MI_LIBPTHREAD)                      
     list(APPEND mi_libraries ${MI_LIBPTHREAD})
+    set(pc_libraries "-pthread")
   endif()
   find_library(MI_LIBRT rt)
   if(MI_LIBRT)
     list(APPEND mi_libraries ${MI_LIBRT})
-  endif()  
+    set(pc_libraries "${pc_libraries} -lrt")
+  endif()
   find_library(MI_LIBATOMIC atomic)
   if (MI_LIBATOMIC OR MI_USE_LIBATOMIC) 
     list(APPEND mi_libraries atomic)
+    set(pc_libraries "${pc_libraries} -latomic")
   endif()
 endif()
 
@@ -375,6 +379,15 @@ if (MI_BUILD_OBJECT)
           DESTINATION ${mi_install_objdir}
           RENAME ${mi_basename}${CMAKE_C_OUTPUT_EXTENSION} )
 endif()
+
+# pkg-config file support
+include("cmake/JoinPaths.cmake")
+join_paths(includedir_for_pc_file "\${prefix}" "${CMAKE_INSTALL_INCLUDEDIR}")
+join_paths(libdir_for_pc_file "\${prefix}" "${CMAKE_INSTALL_LIBDIR}")
+
+configure_file(mimalloc.pc.in mimalloc.pc @ONLY)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/mimalloc.pc"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig/")
 
 # -----------------------------------------------------------------------------
 # API surface testing

--- a/cmake/JoinPaths.cmake
+++ b/cmake/JoinPaths.cmake
@@ -1,0 +1,23 @@
+# This module provides function for joining paths
+# known from most languages
+#
+# SPDX-License-Identifier: (MIT OR CC0-1.0)
+# Copyright 2020 Jan Tojnar
+# https://github.com/jtojnar/cmake-snips
+#
+# Modelled after Python’s os.path.join
+# https://docs.python.org/3.7/library/os.path.html#os.path.join
+# Windows not supported
+function(join_paths joined_path first_path_segment)
+    set(temp_path "${first_path_segment}")
+    foreach(current_segment IN LISTS ARGN)
+        if(NOT ("${current_segment}" STREQUAL ""))
+            if(IS_ABSOLUTE "${current_segment}")
+                set(temp_path "${current_segment}")
+            else()
+                set(temp_path "${temp_path}/${current_segment}")
+            endif()
+        endif()
+    endforeach()
+    set(${joined_path} "${temp_path}" PARENT_SCOPE)
+endfunction()

--- a/mimalloc.pc.in
+++ b/mimalloc.pc.in
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=@libdir_for_pc_file@
+includedir=@includedir_for_pc_file@
+
+Name: @PROJECT_NAME@
+Description: a compact general purpose allocator with excellent performance
+Version: @PROJECT_VERSION@
+URL: https://github.com/microsoft/mimalloc/
+Libs: -L${libdir} -lmimalloc
+Libs.private: @pc_libraries@
+Cflags: -I${includedir}


### PR DESCRIPTION
pkg-config allows using the library in build systems that are not cmake, by exporting the same information from the cmake -config files in a buildsystem-neutral format.

Fixes #16

...

Submission containing materials of a third party:

Author: Jan Tojnar (@jtojnar)
Source: https://github.com/jtojnar/cmake-snips
License: dual-licensed under [MIT](https://github.com/jtojnar/cmake-snips/blob/master/LICENSE.md) and [CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/).

