### PR TITLE
adding check for ptr cookie to be the same as segment cookie to catch…

### DIFF
--- a/src/segment-cache.c
+++ b/src/segment-cache.c
@@ -385,7 +385,15 @@ static bool  mi_is_valid_pointer(const void* p) {
 }
 
 mi_decl_nodiscard mi_decl_export bool mi_is_in_heap_region(const void* p) mi_attr_noexcept {
-  return mi_is_valid_pointer(p);
+  if mi_likely(mi_is_valid_pointer(p)) {
+    return true;
+  }
+
+  // when unable to allocate aligned OS memory directly, pointer cookie is same as segment cookie
+  mi_segment_t* const segment = _mi_ptr_segment(p);
+  if (segment == NULL) return false;
+
+  return (_mi_ptr_cookie(segment) == segment->cookie);
 }
 
 /*


### PR DESCRIPTION
mi_is_in_heap_region returns false for pointers allocated by mimalloc who were allocated along the overallocate path, see osc.c (782-794).

```
    // overallocate...
    p = mi_os_mem_alloc(over_size, 1, commit, false, is_large, stats);
    if (p == NULL) return NULL;
    // and selectively unmap parts around the over-allocated area. (noop on sbrk)
    void* aligned_p = mi_align_up_ptr(p, alignment);
    size_t pre_size = (uint8_t*)aligned_p - (uint8_t*)p;
    size_t mid_size = _mi_align_up(size, _mi_os_page_size());
    size_t post_size = over_size - pre_size - mid_size;
    mi_assert_internal(pre_size < over_size && post_size < over_size && mid_size >= size);
    if (pre_size > 0)  mi_os_mem_free(p, pre_size, commit, stats);
    if (post_size > 0) mi_os_mem_free((uint8_t*)aligned_p + mid_size, post_size, commit, stats);
    // we can return the aligned pointer on `mmap` (and sbrk) systems
    p = aligned_p;
  ```