### PR TITLE
FIX: atomic_store_explicit call in random.c for some arm platform

### DIFF
--- a/src/random.c
+++ b/src/random.c
@@ -260,7 +260,7 @@ static bool os_random_buf(void* buf, size_t buf_len) {
     ssize_t ret = syscall(SYS_getrandom, buf, buf_len, GRND_NONBLOCK);
     if (ret >= 0) return (buf_len == (size_t)ret);
     if (errno != ENOSYS) return false;
-    mi_atomic_store_release(&no_getrandom, 1UL); // don't call again, and fall back to /dev/urandom
+    mi_atomic_store_release(&no_getrandom, (uintptr_t)1); // don't call again, and fall back to /dev/urandom
   }
 #endif
   int flags = O_RDONLY;


### PR DESCRIPTION
In some arm platforms, like cortex-a9. the actual type of `uintptr_t` is not `long unsigned int` but `unsigned int`.
in this situation, the function call won't be compiled.
![image](https://user-images.githubusercontent.com/5518286/217978360-a3923b98-6b25-4bc9-b9a8-c98e49e04acc.png)
error will be like
```
error: no matching function for call to ‘atomic_store_explicit(std::atomic<unsigned int>*, long unsigned int, std::memory_order)’
```

so maybe that force to convert the second argument to the `uintptr_t` type is a better choice.