### PR TITLE
Fix compilation

### DIFF
--- a/src/prim/unix/prim.c
+++ b/src/prim/unix/prim.c
@@ -79,7 +79,7 @@ static int mi_prim_access(const char *fpath, int mode) {
 #elif !defined(__APPLE__)  // avoid unused warnings
 
 static int mi_prim_open(const char* fpath, int open_flags) {
-  return open(fpath,open_flags,mode);
+  return open(fpath,open_flags);
 }
 static ssize_t mi_prim_read(int fd, void* buf, size_t bufsize) {
   return read(fd,buf,bufsize);


### PR DESCRIPTION
FAILED: /home/tarsin/Acme/out/soong/.intermediates/external/mimalloc/libmimalloc/android_ramdisk_arm64_armv8-2a-dotprod_cortex-a76_static/obj/external/mimalloc/src/static.o
PWD=/proc/self/cwd prebuilts/clang/host/linux-x86/clang-r450784d/bin/clang -c -D__ANDROID_RAMDISK__  -Werror=implicit-function-declaration -DANDROID -fmessage-length=0 -W -Wall -Wno-unused -Winit-self -Wpointer-arith -Wunreachable-code-loop-increment -no-canonical-prefixes -DNDEBUG -UDEBUG -fno-exceptions -Wno-multichar -O3 -g -fdebug-default-version=5 -fno-strict-aliasing -Werror=date-time -Werror=pragma-pack -Werror=pragma-pack-suspicious-include -Werror=string-plus-int -Werror=unreachable-code-loop-increment -D__compiler_offsetof=__builtin_offsetof -faddrsig -fcommon -Werror=int-conversion -fexperimental-new-pass-manager -Wno-reserved-id-macro -fcolor-diagnostics -Wno-sign-compare -Wno-defaulted-function-deleted -Wno-inconsistent-missing-override -Wno-c99-designator -Wno-gnu-designator -Wno-gnu-folding-constant -Wunguarded-availability -D__ANDROID_UNAVAILABLE_SYMBOLS_ARE_WEAK__ -ffp-contract=off -fdebug-prefix-map=/proc/self/cwd= -ftrivial-auto-var-init=zero -enable-trivial-auto-var-init-zero-knowing-it-will-be-removed-from-clang -ffunction-sections -fdata-sections -fno-short-enums -funwind-tables -fstack-protector-strong -Wa,--noexecstack -D_FORTIFY_SOURCE=2 -Wstrict-aliasing=2 -Werror=return-type -Werror=non-virtual-dtor -Werror=address -Werror=sequence-point -Werror=format-security -nostdlibinc -fdebug-info-for-profiling -Wno-enum-compare -Wno-enum-compare-switch -Wno-null-pointer-arithmetic -Wno-null-dereference -Wno-pointer-compare -Wno-xor-used-as-pow -Wno-final-dtor-non-final-class -Wno-psabi -Wno-null-pointer-subtraction -Wno-string-concatenation -march=armv8.2-a+dotprod -mcpu=cortex-a55 -target aarch64-linux-android10000 -fPIC  -Iexternal/mimalloc/include -Iexternal/mimalloc/src -Iexternal/mimalloc/include -Iexternal/mimalloc -isystem bionic/libc/include -isystem bionic/libc/kernel/uapi/asm-arm64 -isystem bionic/libc/kernel/uapi -isystem bionic/libc/kernel/android/scsi -isystem bionic/libc/kernel/android/uapi -Wall -Werror -DNDEBUG -Ofast -fPIC -Wall -Wextra -fvisibility=hidden -ftls-model=initial-exec -funroll-loops -fno-emulated-tls -Wno-static-in-inline -Wno-unused-parameter -Wno-unused-function -Wno-missing-field-initializers -std=gnu11 -Isystem/core/include -Isystem/logging/liblog/include -Isystem/media/audio/include -Ihardware/libhardware/include -Ihardware/libhardware_legacy/include -Ihardware/ril/include -Iframeworks/native/include -Iframeworks/native/opengl/include -Iframeworks/av/include  -Werror=bool-operation -Werror=implicit-int-float-conversion -Werror=int-in-bool-context -Werror=int-to-pointer-cast -Werror=pointer-to-int-cast -Werror=string-compare -Werror=xor-used-as-pow -Wno-void-pointer-to-enum-cast -Wno-void-pointer-to-int-cast -Wno-pointer-to-int-cast -Werror=fortify-source -Werror=address-of-temporary -Werror=return-type -Wno-tautological-constant-compare -Wno-tautological-type-limit-compare -Wno-reorder-init-list -Wno-implicit-int-float-conversion -Wno-sizeof-array-div -Wno-tautological-overlap-compare -Wno-deprecated-copy -Wno-range-loop-construct -Wno-misleading-indentation -Wno-zero-as-null-pointer-constant -Wno-deprecated-anon-enum-enum-conversion -Wno-string-compare -Wno-pessimizing-move -Wno-non-c-typedef-for-linkage -Wno-align-mismatch -Wno-error=unused-but-set-variable -Wno-error=unused-but-set-parameter -Wno-unused-but-set-variable -Wno-unused-but-set-parameter -Wno-bitwise-instead-of-logical -MD -MF /home/tarsin/Acme/out/soong/.intermediates/external/mimalloc/libmimalloc/android_ramdisk_arm64_armv8-2a-dotprod_cortex-a76_static/obj/external/mimalloc/src/static.o.d -o /home/tarsin/Acme/out/soong/.intermediates/external/mimalloc/libmimalloc/android_ramdisk_arm64_armv8-2a-dotprod_cortex-a76_static/obj/external/mimalloc/src/static.o external/mimalloc/src/static.c
In file included from external/mimalloc/src/static.c:44:
In file included from external/mimalloc/src/prim/prim.c:22:
external/mimalloc/src/prim/unix/prim.c:82:32: error: use of undeclared identifier 'mode'
  return open(fpath,open_flags,mode);
                               ^
1 error generated.