### PR TITLE
Fix compile error in v2.1.0

### DIFF
--- a/src/prim/unix/prim.c
+++ b/src/prim/unix/prim.c
@@ -391,7 +391,7 @@ int _mi_prim_reset(void* start, size_t size) {
     err = unix_madvise(start, size, MADV_DONTNEED);
   }
   #else
-  int err = unix_madvise(start, csize, MADV_DONTNEED);
+  int err = unix_madvise(start, size, MADV_DONTNEED);
   #endif
   return err;
 }


### PR DESCRIPTION
```
$SRC_DIR/src/prim/unix/prim.c: In function '_mi_prim_reset':
$SRC_DIR/src/prim/unix/prim.c:394:33: error: 'csize' undeclared (first use in this function); did you mean 'size'?
  394 |   int err = unix_madvise(start, csize, MADV_DONTNEED);
      |                                 ^~~~~
      |                                 size
$SRC_DIR/src/prim/unix/prim.c:394:33: note: each undeclared identifier is reported only once for each function it appears in
$SRC_DIR/src/prim/unix/prim.c:382:40: warning: unused parameter 'size' [-Wunused-parameter]
  382 | int _mi_prim_reset(void* start, size_t size) {
      |                                 ~~~~~~~^~~~
```