### PR TITLE
Fix compilation on Android

### DIFF
--- a/include/mimalloc/atomic.h
+++ b/include/mimalloc/atomic.h
@@ -281,7 +281,7 @@ typedef _Atomic(uintptr_t) mi_atomic_once_t;
 static inline bool mi_atomic_once( mi_atomic_once_t* once ) {
   if (mi_atomic_load_relaxed(once) != 0) return false;     // quick test 
   uintptr_t expected = 0;
-  return mi_atomic_cas_strong_acq_rel(once, &expected, 1); // try to set to 1
+  return mi_atomic_cas_strong_acq_rel(once, &expected, 1UL); // try to set to 1
 }
 
 // Yield


### PR DESCRIPTION
https://github.com/microsoft/mimalloc/blob/5ac9e36ed6ed8e5d33f95f733c3a7fbeb9211a7c/include/mimalloc/atomic.h#L284

The above line fails to compile on Android with incorrect function signature error caused by the 3rd argument, changing `1` to `1UL` (explicit unsigned long) fixes it and allows successful compilation under aarch64 Android with Termux, using clang 15.0.7