### PR TITLE
add bin/ to .gitattributes as export-ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,3 +10,4 @@
 *.dll binary
 *.lib binary
 *.exe binary
+bin export-ignore


### PR DESCRIPTION
source tarballs do not include *.dll, *.lib, *.exe