### PR TITLE
Define reallocarr as weak to avoid symbol collision on gnu/Linux.

### DIFF
--- a/src/alloc-override.c
+++ b/src/alloc-override.c
@@ -260,7 +260,10 @@ extern "C" {
 void  cfree(void* p)                                    { mi_free(p); }
 void* pvalloc(size_t size)                              { return mi_pvalloc(size); }
 void* reallocarray(void* p, size_t count, size_t size)  { return mi_reallocarray(p, count, size); }
-int   reallocarr(void* p, size_t count, size_t size)    { return mi_reallocarr(p, count, size); }
+// reallocarr is defined weak as it may result in duplicated symbols errors if linked against other
+// libraries like libedit which have defined a configure-time replacement for reallocarr on systems
+// where the default libc doesn't provide this symbol (ie Linux using glibc).
+__attribute__((weak)) int reallocarr(void* p, size_t count, size_t size)    { return mi_reallocarr(p, count, size); }
 void* memalign(size_t alignment, size_t size)           { return mi_memalign(alignment, size); }
 void* _aligned_malloc(size_t alignment, size_t size)    { return mi_aligned_alloc(alignment, size); }
 


### PR DESCRIPTION
Closes #744.

Note: I am pretty sure this first try is not ok, as I am pretty sure not all compilers will accept this `__attribute__` thing, most likely the MSCV compiler, and given you work in Microsoft, I think you care about this :D In `src/alloc.c:925` you have surrounded the `__attribute__((weak))` usage by `#if (defined(__GNUC__) || (defined(__clang__) && !defined(_MSC_VER)))`, do you want me to also use this conditional here ?