### PR TITLE
allow configure page & segment sizes from build args

### DIFF
--- a/include/mimalloc/types.h
+++ b/include/mimalloc/types.h
@@ -157,12 +157,16 @@ typedef int32_t  mi_ssize_t;
 
 // Main tuning parameters for segment and page sizes
 // Sizes for 64-bit (usually divide by two for 32-bit)
+#ifndef MI_SEGMENT_SLICE_SHIFT
 #define MI_SEGMENT_SLICE_SHIFT            (13 + MI_INTPTR_SHIFT)         // 64KiB  (32KiB on 32-bit)
+#endif
 
+#ifndef MI_SEGMENT_SHIFT
 #if MI_INTPTR_SIZE > 4
 #define MI_SEGMENT_SHIFT                  ( 9 + MI_SEGMENT_SLICE_SHIFT)  // 32MiB
 #else
 #define MI_SEGMENT_SHIFT                  ( 7 + MI_SEGMENT_SLICE_SHIFT)  // 4MiB on 32-bit
+#endif
 #endif
 
 #define MI_SMALL_PAGE_SHIFT               (MI_SEGMENT_SLICE_SHIFT)       // 64KiB


### PR DESCRIPTION
i.e. compiler's command-line. This improves maintanability since one do not have to modify upstream sources (which cause additional maintability burden on updates)

Note: sorry about using wrong branch for this PR (according to docs it should be `dev`, and not `dev-slice`), but `dev` has slightly different way of defining this consts which conflicts with this commit.