### PR TITLE
Fix undefined symbol errors when building for wasi

### DIFF
--- a/include/mimalloc/internal.h
+++ b/include/mimalloc/internal.h
@@ -115,6 +115,8 @@ size_t     _mi_os_large_page_size(void);
 
 void*      _mi_os_alloc_huge_os_pages(size_t pages, int numa_node, mi_msecs_t max_secs, size_t* pages_reserved, size_t* psize, mi_memid_t* memid);
 
+void*      mi_align_up_ptr(void* p, size_t alignment);
+
 // arena.c
 mi_arena_id_t _mi_arena_id_none(void);
 void       _mi_arena_free(void* p, size_t size, size_t still_committed_size, mi_memid_t memid, mi_stats_t* stats);

--- a/src/os.c
+++ b/src/os.c
@@ -73,7 +73,7 @@ void _mi_os_init(void) {
 bool _mi_os_decommit(void* addr, size_t size, mi_stats_t* stats);
 bool _mi_os_commit(void* addr, size_t size, bool* is_zero, mi_stats_t* tld_stats);
 
-static void* mi_align_up_ptr(void* p, size_t alignment) {
+void* mi_align_up_ptr(void* p, size_t alignment) {
   return (void*)_mi_align_up((uintptr_t)p, alignment);
 }
 

--- a/src/prim/wasi/prim.c
+++ b/src/prim/wasi/prim.c
@@ -8,6 +8,7 @@ terms of the MIT license. A copy of the license can be found in the file
 // This file is included in `src/prim/prim.c`
 
 #include <stdio.h>
+#include <stdlib.h>
 
 #include "mimalloc.h"
 #include "mimalloc/internal.h"

--- a/src/prim/wasi/prim.c
+++ b/src/prim/wasi/prim.c
@@ -7,6 +7,8 @@ terms of the MIT license. A copy of the license can be found in the file
 
 // This file is included in `src/prim/prim.c`
 
+#include <stdio.h>
+
 #include "mimalloc.h"
 #include "mimalloc/internal.h"
 #include "mimalloc/atomic.h"

--- a/src/prim/wasi/prim.c
+++ b/src/prim/wasi/prim.c
@@ -40,6 +40,7 @@ int _mi_prim_free(void* addr, size_t size ) {
 //---------------------------------------------
 
 #if defined(MI_USE_SBRK)
+  #include <unistd.h>
   static void* mi_memory_grow( size_t size ) {
     void* p = sbrk(size);
     if (p == (void*)(-1)) return NULL;


### PR DESCRIPTION
It's been a while since updating my wasi build's dependency so tried and found these undefined symbol errors. Not sure if all of these fixes make sense, let me know

```
#0 2.187 /mimalloc/src/prim/wasi/prim.c:44:15: error: call to undeclared function 'sbrk'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]

#0 1.874 /mimalloc/src/prim/wasi/prim.c:89:33: error: call to undeclared function 'mi_align_up_ptr'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
#0 1.874         void* aligned_current = mi_align_up_ptr(current, try_alignment);  // and align from there to minimize wasted space

#0 1.978 /mimalloc/src/prim/wasi/prim.c:225:3: error: call to undeclared function 'fputs'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
#0 1.979   fputs(msg,stderr);
#0 1.979   ^

#0 1.979 /mimalloc/src/prim/wasi/prim.c:236:19: error: call to undeclared function 'getenv'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
#0 1.979   const char* s = getenv(name);
#0 2.187     void* p = sbrk(size);
```