### PR TITLE
Fix compile error on OpenBSD

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -455,7 +455,7 @@ void _mi_heap_set_default_direct(mi_heap_t* heap)  {
   #if defined(MI_TLS_SLOT)
   mi_prim_tls_slot_set(MI_TLS_SLOT,heap);
   #elif defined(MI_TLS_PTHREAD_SLOT_OFS)
-  *mi_tls_pthread_heap_slot() = heap;
+  *mi_prim_tls_pthread_heap_slot() = heap;
   #elif defined(MI_TLS_PTHREAD)
   // we use _mi_heap_default_key
   #else


### PR DESCRIPTION
Compile error:
```
/data/mimalloc/src/init.c:458:4: warning: implicit declaration of function 'mi_tls_pthread_heap_slot' is invalid in C99 [-Wimplicit-function-declaration]
  *mi_tls_pthread_heap_slot() = heap;
   ^
/data/mimalloc/src/init.c:458:3: error: indirection requires pointer operand ('int' invalid)
  *mi_tls_pthread_heap_slot() = heap;
```