### PR TITLE
prim.h: support tls_slot for PPC

### DIFF
--- a/include/mimalloc/prim.h
+++ b/include/mimalloc/prim.h
@@ -146,7 +146,7 @@ static inline mi_threadid_t _mi_prim_thread_id(void) mi_attr_noexcept {
 // see also https://akkadia.org/drepper/tls.pdf for more info on the TLS register.
 #elif defined(__GNUC__) && ( \
            (defined(__GLIBC__)   && (defined(__x86_64__) || defined(__i386__) || defined(__arm__) || defined(__aarch64__))) \
-        || (defined(__APPLE__)   && (defined(__x86_64__) || defined(__aarch64__))) \
+        || (defined(__APPLE__)   && (defined(__x86_64__) || defined(__aarch64__) || defined(__POWERPC__))) \
         || (defined(__BIONIC__)  && (defined(__x86_64__) || defined(__i386__) || defined(__arm__) || defined(__aarch64__))) \
         || (defined(__FreeBSD__) && (defined(__x86_64__) || defined(__i386__) || defined(__aarch64__))) \
         || (defined(__OpenBSD__) && (defined(__x86_64__) || defined(__i386__) || defined(__aarch64__))) \
@@ -175,6 +175,9 @@ static inline void* mi_prim_tls_slot(size_t slot) mi_attr_noexcept {
     __asm__ volatile ("mrs %0, tpidr_el0" : "=r" (tcb));
     #endif
     res = tcb[slot];
+  #elif defined(__POWERPC__)
+    MI_UNUSED(ofs);
+    res = pthread_getspecific(slot);
   #endif
   return res;
 }
@@ -202,6 +205,9 @@ static inline void mi_prim_tls_slot_set(size_t slot, void* value) mi_attr_noexce
     __asm__ volatile ("mrs %0, tpidr_el0" : "=r" (tcb));
     #endif
     tcb[slot] = value;
+  #elif defined(__POWERPC__)
+    int res; MI_UNUSED(ofs);
+    res = pthread_setspecific(slot, value);
   #endif
 }
 


### PR DESCRIPTION
Provisionally this works for Darwin PPC. I get tests pass:
```
--->  Testing mimalloc
Executing:  cd "/opt/local/var/macports/build/_opt_PPCSnowLeopardPorts_devel_mimalloc/mimalloc/work/build" && /usr/bin/make test 
Running tests...
/opt/local/bin/ctest --force-new-ctest-process 
Test project /opt/local/var/macports/build/_opt_PPCSnowLeopardPorts_devel_mimalloc/mimalloc/work/build
    Start 1: test-api
1/3 Test #1: test-api .........................   Passed    0.69 sec
    Start 2: test-api-fill
2/3 Test #2: test-api-fill ....................   Passed    0.01 sec
    Start 3: test-stress
3/3 Test #3: test-stress ......................   Passed    0.99 sec

100% tests passed, 0 tests failed out of 3

Total Test time (real) =   1.70 sec
```
However, for that two conditions should be met:
1. `-DMI_OSX_INTERPOSE=OFF -DMI_OSX_ZONE=OFF -DMI_USE_LIBATOMIC=ON`; enabling interpose does not work: https://github.com/microsoft/mimalloc/issues/779
2. Realpath test case has to be disabled; this is a genuine bug in `mimalloc` and not PowerPC-related, see: https://github.com/microsoft/mimalloc/issues/778