### PR TITLE
Revert setting hardcoded install paths on Haiku

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,11 +262,6 @@ if(MI_USE_CXX)
   endif()
 endif()
 
-if(CMAKE_SYSTEM_NAME MATCHES "Haiku")
-   SET(CMAKE_INSTALL_LIBDIR ~/config/non-packaged/lib)
-   SET(CMAKE_INSTALL_INCLUDEDIR ~/config/non-packaged/headers)
- endif()
-
 # Compiler flags
 if(CMAKE_C_COMPILER_ID MATCHES "AppleClang|Clang|GNU")
   list(APPEND mi_cflags -Wall -Wextra -Wno-unknown-pragmas -fvisibility=hidden)


### PR DESCRIPTION
This should be done manually with `-DCMAKE_INSTALL_PREFIX` (getting in the way for packaging it on Haiku with our tool `haikuporter`).