### PR TITLE
Fix for issue #809: Delete the key at shutdown

### DIFF
--- a/src/prim/unix/prim.c
+++ b/src/prim/unix/prim.c
@@ -833,7 +833,7 @@ void _mi_prim_thread_init_auto_done(void) {
 }
 
 void _mi_prim_thread_done_auto_done(void) {
-  // nothing to do
+  pthread_key_delete(_mi_heap_default_key);
 }
 
 void _mi_prim_thread_associate_default_heap(mi_heap_t* heap) {


### PR DESCRIPTION
See issue #809 