### PR TITLE
Fix error: cannot use 'throw' with exceptions disabled

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -913,9 +913,13 @@ static bool mi_try_new_handler(bool nothrow) {
   #endif
   if (h==NULL) {
     _mi_error_message(ENOMEM, "out of memory in 'new'");
+    #if defined(_CPPUNWIND) || defined(__cpp_exceptions)
     if (!nothrow) {
       throw std::bad_alloc();
     }
+    #else
+    (void)nothrow;
+    #endif
     return false;
   }
   else {


### PR DESCRIPTION
`mimalloc` should compile even if exceptions are disabled by the MSVC
or GCC or Clang command-line options.
