### PR TITLE
Fix bug where allocating a new arena would not zero memory correctly

### DIFF
--- a/src/arena.c
+++ b/src/arena.c
@@ -179,7 +179,11 @@ static void* mi_arena_meta_zalloc(size_t size, mi_memid_t* memid, mi_stats_t* st
   if (p != NULL) return p;
 
   // or fall back to the OS
-  return _mi_os_alloc(size, memid, stats);
+  p = _mi_os_alloc(size,memid,stats);
+  if (p != NULL  && !memid->initially_zero) {
+	  _mi_memzero(p,size);
+  }
+  return p;
 }
 
 static void mi_arena_meta_free(void* p, mi_memid_t memid, size_t size, mi_stats_t* stats) {


### PR DESCRIPTION
When porting mimalloc to playstation, it was found that the function `mi_arena_meta_zalloc` does not zero allocate the memory when it falls back to `_mi_os_alloc`. This caused issues on a running application. This pr fixes it by checking if the os memory was already zeroed, and if it wasnt it zeros the allocation.