### PR TITLE
Use proper libc stubs instead of direct syscalls on OpenBSD

### DIFF
--- a/src/prim/unix/prim.c
+++ b/src/prim/unix/prim.c
@@ -27,10 +27,10 @@ terms of the MIT license. A copy of the license can be found in the file
 
 #include <sys/mman.h>  // mmap
 #include <unistd.h>    // sysconf
+#include <fcntl.h>     // open
 
 #if defined(__linux__)
   #include <features.h>
-  #include <fcntl.h>
   #if defined(__GLIBC__)
   #include <linux/mman.h> // linux mmap flags
   #else
@@ -50,7 +50,7 @@ terms of the MIT license. A copy of the license can be found in the file
   #include <sys/sysctl.h>
 #endif
 
-#if !defined(__HAIKU__) && !defined(__APPLE__) && !defined(__CYGWIN__)
+#if !defined(__HAIKU__) && !defined(__APPLE__) && !defined(__CYGWIN__) && !defined(__OpenBSD__)
   #define MI_HAS_SYSCALL_H
   #include <sys/syscall.h>
 #endif
@@ -762,7 +762,6 @@ bool _mi_prim_random_buf(void* buf, size_t buf_len) {
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <fcntl.h>
 #include <errno.h>
 
 bool _mi_prim_random_buf(void* buf, size_t buf_len) {


### PR DESCRIPTION
Make #include fcntl.h unconditional to avoid implicit definitions.

--------

As OpenBSD is removing `syscall` function from libc we are doing sweeps through the ported software to make sure it still compiles cleanly. This change enables us to build mimalloc without warnings.