### PR TITLE
avoid unused function warnings when building on Solaris

### DIFF
--- a/src/prim/unix/prim.c
+++ b/src/prim/unix/prim.c
@@ -50,7 +50,7 @@ terms of the MIT license. A copy of the license can be found in the file
   #include <sys/sysctl.h>
 #endif
 
-#if !defined(__HAIKU__) && !defined(__APPLE__) && !defined(__CYGWIN__)
+#if !defined(__HAIKU__) && !defined(__APPLE__) && !defined(__CYGWIN__) && !defined(__sun)
   #define MI_HAS_SYSCALL_H
   #include <sys/syscall.h>
 #endif
@@ -76,7 +76,7 @@ static int mi_prim_access(const char *fpath, int mode) {
   return syscall(SYS_access,fpath,mode);
 }
 
-#elif !defined(__APPLE__)  // avoid unused warnings
+#elif !defined(__APPLE__) && !defined(__sun)  // avoid unused warnings
 
 static int mi_prim_open(const char* fpath, int open_flags) {
   return open(fpath,open_flags);


### PR DESCRIPTION
When building mimalloc on Solaris, we are seeing unused function warnings:
```
/.../cpython-main/Objects/mimalloc/prim/unix/prim.c: At top level:
/.../cpython-main/Objects/mimalloc/prim/unix/prim.c:90:12: warning: 'mi_prim_access' defined but not used [-Wunused-function]
   90 | static int mi_prim_access(const char *fpath, int mode) {
      |            ^~~~~~~~~~~~~~
/.../cpython-main/Objects/mimalloc/prim/unix/prim.c:87:12: warning: 'mi_prim_close' defined but not used [-Wunused-function]
   87 | static int mi_prim_close(int fd) {
      |            ^~~~~~~~~~~~~
/.../cpython-main/Objects/mimalloc/prim/unix/prim.c:84:16: warning: 'mi_prim_read' defined but not used [-Wunused-function]
   84 | static ssize_t mi_prim_read(int fd, void* buf, size_t bufsize) {
      |                ^~~~~~~~~~~~
/.../cpython-main/Objects/mimalloc/prim/unix/prim.c:81:12: warning: 'mi_prim_open' defined but not used [-Wunused-function]
   81 | static int mi_prim_open(const char* fpath, int open_flags) {
      |            ^~~~~~~~~~~~
```

This was noticed when building latest Python main; here is the downstream report:
https://github.com/python/cpython/issues/112806
