### PR TITLE
Ensure consistent types for template deduction

### DIFF
--- a/src/arena.c
+++ b/src/arena.c
@@ -479,7 +479,7 @@ static void mi_arena_schedule_purge(mi_arena_t* arena, size_t bitmap_idx, size_t
     // schedule decommit
     mi_msecs_t expire = mi_atomic_loadi64_relaxed(&arena->purge_expire);
     if (expire != 0) {
-      mi_atomic_addi64_acq_rel(&arena->purge_expire, delay/10);  // add smallish extra delay
+      mi_atomic_addi64_acq_rel(&arena->purge_expire, (mi_msecs_t)delay/10);  // add smallish extra delay
     }
     else {
       mi_atomic_storei64_release(&arena->purge_expire, _mi_clock_now() + delay);
@@ -523,7 +523,7 @@ static bool mi_arena_try_purge(mi_arena_t* arena, mi_msecs_t now, bool force, mi
   if (!force && expire > now) return false;
 
   // reset expire (if not already set concurrently)
-  mi_atomic_casi64_strong_acq_rel(&arena->purge_expire, &expire, 0);
+  mi_atomic_casi64_strong_acq_rel(&arena->purge_expire, &expire, (mi_msecs_t)0);
   
   // potential purges scheduled, walk through the bitmap
   bool any_purged = false;


### PR DESCRIPTION
Android builds of the vcpkg port using NDK r25c were failing. Cf. arm64-android assets at 
https://dev.azure.com/vcpkg/public/_build/results?buildId=97594&view=artifacts&pathAsName=false&type=publishedArtifacts
~~~
FAILED: CMakeFiles/mimalloc-static.dir/src/arena.c.o 
/android-ndk-r25c/toolchains/llvm/prebuilt/linux-x86_64/bin/clang++ --target=aarch64-none-linux-android21 --sysroot=/android-ndk-r25c/toolchains/llvm/prebuilt/linux-x86_64/sysroot -DMI_DEBUG=3 -DMI_STATIC_LIB -I/mnt/vcpkg-ci/buildtrees/mimalloc/src/v2.1.2-e5b75009a9.clean/include -g -DANDROID -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security -frtti -fexceptions  -fPIC   -fno-limit-debug-info    -std=gnu++17 -fPIC -Wno-deprecated -Wall -Wextra -Wno-unknown-pragmas -fvisibility=hidden -Wpedantic -Wno-static-in-inline -ftls-model=initial-exec -MD -MT CMakeFiles/mimalloc-static.dir/src/arena.c.o -MF CMakeFiles/mimalloc-static.dir/src/arena.c.o.d -o CMakeFiles/mimalloc-static.dir/src/arena.c.o -c /mnt/vcpkg-ci/buildtrees/mimalloc/src/v2.1.2-e5b75009a9.clean/src/arena.c
/mnt/vcpkg-ci/buildtrees/mimalloc/src/v2.1.2-e5b75009a9.clean/src/arena.c:523:3: error: no matching function for call to 'atomic_compare_exchange_strong_explicit'
  mi_atomic_casi64_strong_acq_rel(&arena->purge_expire, &expire, 0);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/mnt/vcpkg-ci/buildtrees/mimalloc/src/v2.1.2-e5b75009a9.clean/include/mimalloc/atomic.h:125:49: note: expanded from macro 'mi_atomic_casi64_strong_acq_rel'
#define mi_atomic_casi64_strong_acq_rel(p,e,d)  mi_atomic_cas_strong_acq_rel(p,e,d)
                                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/mnt/vcpkg-ci/buildtrees/mimalloc/src/v2.1.2-e5b75009a9.clean/include/mimalloc/atomic.h:65:50: note: expanded from macro 'mi_atomic_cas_strong_acq_rel'
#define mi_atomic_cas_strong_acq_rel(p,exp,des)  mi_atomic_cas_strong(p,exp,des,mi_memory_order(acq_rel),mi_memory_order(acquire))
                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/mnt/vcpkg-ci/buildtrees/mimalloc/src/v2.1.2-e5b75009a9.clean/include/mimalloc/atomic.h:54:3: note: expanded from macro 'mi_atomic_cas_strong'
  mi_atomic(compare_exchange_strong_explicit)(p,expected,desired,mem_success,mem_fail)
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/mnt/vcpkg-ci/buildtrees/mimalloc/src/v2.1.2-e5b75009a9.clean/include/mimalloc/atomic.h:24:33: note: expanded from macro 'mi_atomic'
#define  mi_atomic(name)        std::atomic_##name
                                ^~~~~~~~~~~~~~~~~~
/android-ndk-r25c/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/c++/v1/atomic:2043:1: note: candidate template ignored: deduced conflicting types for parameter '_Tp' ('long' vs. 'int')
atomic_compare_exchange_strong_explicit(volatile atomic<_Tp>* __o,
^
/android-ndk-r25c/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/c++/v1/atomic:2054:1: note: candidate template ignored: deduced conflicting types for parameter '_Tp' ('long' vs. 'int')
atomic_compare_exchange_strong_explicit(atomic<_Tp>* __o, _Tp* __e,
^
/android-ndk-r25c/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/c++/v1/memory:5198:1: note: candidate template ignored: could not match 'shared_ptr' against 'atomic'
atomic_compare_exchange_strong_explicit(shared_ptr<_Tp>* __p, shared_ptr<_Tp>* __v,
^
1 error generated.
~~~
Related:
https://github.com/microsoft/vcpkg/pull/35713
