### PR TITLE
fix illumos build

### DIFF
--- a/src/prim/unix/prim.c
+++ b/src/prim/unix/prim.c
@@ -310,7 +310,7 @@ static void* unix_mmap(void* addr, size_t size, size_t try_alignment, int protec
       #elif defined(__sun)
       if (allow_large && _mi_os_use_large_page(size, try_alignment)) {
         struct memcntl_mha cmd = {0};
-        cmd.mha_pagesize = large_os_page_size;
+        cmd.mha_pagesize = _mi_os_large_page_size();
         cmd.mha_cmd = MHA_MAPSIZE_VA;
         if (memcntl((caddr_t)p, size, MC_HAT_ADVISE, (caddr_t)&cmd, 0, 0) == 0) {
           *is_large = true;


### PR DESCRIPTION
In 08a01d26dc079756c8e94409fba051fd2eb5bd2c, the primitive layer changed and the `large_os_page_size` static was replaced by the `_mi_os_large_page_size` function.  However, an `#elif` predicated by `__sun` that referred to `large_os_page_size` was missed in that change.  This simply changes that reference to the function.