### PR TITLE
Double free abort in secure mode

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -212,7 +212,11 @@ static mi_decl_noinline bool mi_check_is_double_freex(const mi_page_t* page, con
       mi_list_contains(page, page->local_free, block) ||
       mi_list_contains(page, mi_page_thread_free(page), block))
   {
+#if (MI_SECURE > 0)
     _mi_error_message(EFAULT, "double free detected of block %p with size %zu\n", block, mi_page_block_size(page));
+#else
+    _mi_error_message(EAGAIN, "double free detected of block %p with size %zu\n", block, mi_page_block_size(page));
+#endif
     return true;
   }
   return false;

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -212,7 +212,7 @@ static mi_decl_noinline bool mi_check_is_double_freex(const mi_page_t* page, con
       mi_list_contains(page, page->local_free, block) ||
       mi_list_contains(page, mi_page_thread_free(page), block))
   {
-    _mi_error_message(EAGAIN, "double free detected of block %p with size %zu\n", block, mi_page_block_size(page));
+    _mi_error_message(EFAULT, "double free detected of block %p with size %zu\n", block, mi_page_block_size(page));
     return true;
   }
   return false;


### PR DESCRIPTION
In secure mode the library should be aborting on double free instead of swallowing the error. The idea being that you want to err on the side of caution instead of letting the program continue. 