### PR TITLE
Allow for configuration of tuning parameters

### DIFF
--- a/include/mimalloc/types.h
+++ b/include/mimalloc/types.h
@@ -157,16 +157,25 @@ typedef int32_t  mi_ssize_t;
 
 // Main tuning parameters for segment and page sizes
 // Sizes for 64-bit (usually divide by two for 32-bit)
+#ifndef MI_SEGMENT_SLICE_SHIFT
 #define MI_SEGMENT_SLICE_SHIFT            (13 + MI_INTPTR_SHIFT)         // 64KiB  (32KiB on 32-bit)
+#endif
 
+#ifndef MI_SEGMENT_SHIFT
 #if MI_INTPTR_SIZE > 4
 #define MI_SEGMENT_SHIFT                  ( 9 + MI_SEGMENT_SLICE_SHIFT)  // 32MiB
 #else
 #define MI_SEGMENT_SHIFT                  ( 7 + MI_SEGMENT_SLICE_SHIFT)  // 4MiB on 32-bit
 #endif
+#endif
 
+#ifndef MI_SMALL_PAGE_SHIFT
 #define MI_SMALL_PAGE_SHIFT               (MI_SEGMENT_SLICE_SHIFT)       // 64KiB
+#endif
+
+#ifndef MI_MEDIUM_PAGE_SHIFT
 #define MI_MEDIUM_PAGE_SHIFT              ( 3 + MI_SMALL_PAGE_SHIFT)     // 512KiB
+#endif
 
 
 // Derived constants


### PR DESCRIPTION
Currently there is no way for a client application to tune these parameters without forking `mimalloc`. This change allows users to provide these values via their build system.

Related to https://github.com/microsoft/mimalloc/issues/647#issuecomment-1324109021 where it was suggested to change the tuning values, but I have no way of doing so without editing the source directly without this change.