### PR TITLE
Avoid compilation error when passing in heap_t to C++ allocators

### DIFF
--- a/include/mimalloc.h
+++ b/include/mimalloc.h
@@ -487,6 +487,7 @@ template<class T1,class T2> bool operator!=(const mi_stl_allocator<T1>& , const 
 #define MI_HAS_HEAP_STL_ALLOCATOR 1
 
 #include <memory>      // std::shared_ptr
+#include "mimalloc/types.h"
 
 // Common base class for STL allocators in a specific heap
 template<class T, bool _mi_destroy> struct _mi_heap_stl_allocator_common : public _mi_stl_allocator_common<T> {

--- a/include/mimalloc.h
+++ b/include/mimalloc.h
@@ -495,7 +495,7 @@ template<class T, bool _mi_destroy> struct _mi_heap_stl_allocator_common : publi
   using typename _mi_stl_allocator_common<T>::value_type;
   using typename _mi_stl_allocator_common<T>::pointer;
 
-  _mi_heap_stl_allocator_common(mi_heap_t* hp) : heap(hp) { }    /* will not delete nor destroy the passed in heap */
+  _mi_heap_stl_allocator_common(mi_heap_t* hp) : heap(hp, [](mi_heap_t*) {}) {}    /* will not delete nor destroy the passed in heap */
 
   #if (__cplusplus >= 201703L)  // C++17
   mi_decl_nodiscard T* allocate(size_type count) { return static_cast<T*>(mi_heap_alloc_new_n(this->heap.get(), count, sizeof(T))); }

--- a/include/mimalloc.h
+++ b/include/mimalloc.h
@@ -487,7 +487,6 @@ template<class T1,class T2> bool operator!=(const mi_stl_allocator<T1>& , const 
 #define MI_HAS_HEAP_STL_ALLOCATOR 1
 
 #include <memory>      // std::shared_ptr
-#include "mimalloc/types.h"
 
 // Common base class for STL allocators in a specific heap
 template<class T, bool _mi_destroy> struct _mi_heap_stl_allocator_common : public _mi_stl_allocator_common<T> {

--- a/test/test-api.c
+++ b/test/test-api.c
@@ -46,6 +46,11 @@ bool test_heap2(void);
 bool test_stl_allocator1(void);
 bool test_stl_allocator2(void);
 
+bool test_stl_heap_allocator1(void);
+bool test_stl_heap_allocator2(void);
+bool test_stl_heap_allocator3(void);
+bool test_stl_heap_allocator4(void);
+
 bool mem_is_zero(uint8_t* p, size_t size) {
   if (p==NULL) return false;
   for (size_t i = 0; i < size; ++i) {
@@ -304,6 +309,11 @@ int main(void) {
   CHECK("stl_allocator1", test_stl_allocator1());
   CHECK("stl_allocator2", test_stl_allocator2());
 
+	CHECK("stl_heap_allocator1", test_stl_heap_allocator1());
+	CHECK("stl_heap_allocator2", test_stl_heap_allocator2());
+	CHECK("stl_heap_allocator3", test_stl_heap_allocator3());
+	CHECK("stl_heap_allocator4", test_stl_heap_allocator4());
+
   // ---------------------------------------------------
   // Done
   // ---------------------------------------------------[]
@@ -353,6 +363,64 @@ bool test_stl_allocator2(void) {
   vec.push_back(some_struct());
   vec.pop_back();
   return vec.size() == 0;
+#else
+  return true;
+#endif
+}
+
+bool test_stl_heap_allocator1(void) {
+#ifdef __cplusplus
+  std::vector<some_struct, mi_heap_stl_allocator<some_struct> > vec;
+  vec.push_back(some_struct());
+  vec.pop_back();
+  return vec.size() == 0;
+#else
+  return true;
+#endif
+}
+
+bool test_stl_heap_allocator2(void) {
+#ifdef __cplusplus
+  std::vector<some_struct, mi_heap_destroy_stl_allocator<some_struct> > vec;
+  vec.push_back(some_struct());
+  vec.pop_back();
+  return vec.size() == 0;
+#else
+  return true;
+#endif
+}
+
+bool test_stl_heap_allocator3(void) {
+#ifdef __cplusplus
+	mi_heap_t* heap = mi_heap_new();
+	bool good = false;
+	{
+		mi_heap_stl_allocator<some_struct> myAlloc(heap);
+		std::vector<some_struct, mi_heap_stl_allocator<some_struct> > vec(myAlloc);
+		vec.push_back(some_struct());
+		vec.pop_back();
+		good = vec.size() == 0;
+	}
+	mi_heap_delete(heap);
+  return good;
+#else
+  return true;
+#endif
+}
+
+bool test_stl_heap_allocator4(void) {
+#ifdef __cplusplus
+	mi_heap_t* heap = mi_heap_new();
+	bool good = false;
+	{
+		mi_heap_destroy_stl_allocator<some_struct> myAlloc(heap);
+		std::vector<some_struct, mi_heap_destroy_stl_allocator<some_struct> > vec(myAlloc);
+		vec.push_back(some_struct());
+		vec.pop_back();
+		good = vec.size() == 0;
+	}
+	mi_heap_destroy(heap);
+  return good;
 #else
   return true;
 #endif


### PR DESCRIPTION
Before it would not work to create the `mi_heap_stl_allocator` types with passing in a `mi_heap_t*`, since `sizeof` is used and it gives a compilation error. This change fixes that.

Steps to reproduce the current error:

```cpp
include <mimalloc.h>
#include <vector>

int main() {
    mi_heap_t *hp = mi_heap_new();
    mi_heap_destroy_stl_allocator<int> thisOne(hp);
    mi_heap_destroy(hp);
}
```

Compilation error is:
```
====================[ Build | mimalloc-stuff | Debug ]==========================
/home/rhermes/.local/share/JetBrains/Toolbox/apps/clion/bin/cmake/linux/x64/bin/cmake --build /home/rhermes/commons/projects/measure-everything/cmake-build-debug --target mimalloc-stuff -j 22
[1/2] Building CXX object CMakeFiles/mimalloc-stuff.dir/mimalloc-stuff/main.cpp.o
FAILED: CMakeFiles/mimalloc-stuff.dir/mimalloc-stuff/main.cpp.o 
/usr/bin/c++  -I/home/rhermes/commons/projects/measure-everything/cmake-build-debug/_deps/mimalloc-src/include -g -std=gnu++20 -fdiagnostics-color=always -MD -MT CMakeFiles/mimalloc-stuff.dir/mimalloc-stuff/main.cpp.o -MF CMakeFiles/mimalloc-stuff.dir/mimalloc-stuff/main.cpp.o.d -o CMakeFiles/mimalloc-stuff.dir/mimalloc-stuff/main.cpp.o -c /home/rhermes/commons/projects/measure-everything/mimalloc-stuff/main.cpp
In file included from /usr/include/c++/13.2.1/bits/shared_ptr.h:53,
                 from /usr/include/c++/13.2.1/memory:80,
                 from /home/rhermes/commons/projects/measure-everything/cmake-build-debug/_deps/mimalloc-src/include/mimalloc.h:489,
                 from /home/rhermes/commons/projects/measure-everything/mimalloc-stuff/main.cpp:5:
/usr/include/c++/13.2.1/bits/shared_ptr_base.h: In instantiation of ‘std::__shared_ptr<_Tp, _Lp>::__shared_ptr(_Yp*) [with _Yp = mi_heap_s; <template-parameter-2-2> = void; _Tp = mi_heap_s; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]’:
/usr/include/c++/13.2.1/bits/shared_ptr.h:214:46:   required from ‘std::shared_ptr<_Tp>::shared_ptr(_Yp*) [with _Yp = mi_heap_s; <template-parameter-2-2> = void; _Tp = mi_heap_s]’
/home/rhermes/commons/projects/measure-everything/cmake-build-debug/_deps/mimalloc-src/include/mimalloc.h:497:50:   required from ‘_mi_heap_stl_allocator_common<T, _mi_destroy>::_mi_heap_stl_allocator_common(mi_heap_t*) [with T = int; bool _mi_destroy = true; mi_heap_t = mi_heap_s]’
/home/rhermes/commons/projects/measure-everything/cmake-build-debug/_deps/mimalloc-src/include/mimalloc.h:550:91:   required from ‘mi_heap_destroy_stl_allocator<T>::mi_heap_destroy_stl_allocator(mi_heap_t*) [with T = int; mi_heap_t = mi_heap_s]’
/home/rhermes/commons/projects/measure-everything/mimalloc-stuff/main.cpp:10:50:   required from here
/usr/include/c++/13.2.1/bits/shared_ptr_base.h:1472:26: error: invalid application of ‘sizeof’ to incomplete type ‘mi_heap_s’
 1472 |           static_assert( sizeof(_Yp) > 0, "incomplete type" );
      |                          ^~~~~~~~~~~
ninja: build stopped: subcommand failed.
```