### PR TITLE
Avoid compilation error when passing in heap_t to C++ allocators for v2

### DIFF
--- a/include/mimalloc.h
+++ b/include/mimalloc.h
@@ -488,7 +488,6 @@ template<class T1,class T2> bool operator!=(const mi_stl_allocator<T1>& , const 
 #define MI_HAS_HEAP_STL_ALLOCATOR 1
 
 #include <memory>      // std::shared_ptr
-#include "mimalloc/types.h"
 
 // Common base class for STL allocators in a specific heap
 template<class T, bool _mi_destroy> struct _mi_heap_stl_allocator_common : public _mi_stl_allocator_common<T> {

--- a/include/mimalloc.h
+++ b/include/mimalloc.h
@@ -496,7 +496,7 @@ template<class T, bool _mi_destroy> struct _mi_heap_stl_allocator_common : publi
   using typename _mi_stl_allocator_common<T>::value_type;
   using typename _mi_stl_allocator_common<T>::pointer;
 
-  _mi_heap_stl_allocator_common(mi_heap_t* hp) : heap(hp) { }    /* will not delete nor destroy the passed in heap */
+  _mi_heap_stl_allocator_common(mi_heap_t* hp) : heap(hp, [](mi_heap_t*) {}) {}    /* will not delete nor destroy the passed in heap */
 
   #if (__cplusplus >= 201703L)  // C++17
   mi_decl_nodiscard T* allocate(size_type count) { return static_cast<T*>(mi_heap_alloc_new_n(this->heap.get(), count, sizeof(T))); }

--- a/include/mimalloc.h
+++ b/include/mimalloc.h
@@ -488,6 +488,7 @@ template<class T1,class T2> bool operator!=(const mi_stl_allocator<T1>& , const 
 #define MI_HAS_HEAP_STL_ALLOCATOR 1
 
 #include <memory>      // std::shared_ptr
+#include "mimalloc/types.h"
 
 // Common base class for STL allocators in a specific heap
 template<class T, bool _mi_destroy> struct _mi_heap_stl_allocator_common : public _mi_stl_allocator_common<T> {

--- a/include/mimalloc/types.h
+++ b/include/mimalloc/types.h
@@ -303,7 +303,7 @@ typedef struct mi_page_s {
   uint8_t               retire_expire : 7; // expiration count for retired blocks
 
   mi_block_t*           free;              // list of available free blocks (`malloc` allocates from this list)
-  uint32_t              used;              // number of blocks in use (including blocks in `local_free` and `thread_free`)
+  uint32_t              used;              // number of blocks in use (including blocks in `thread_free`)
   uint32_t              xblock_size;       // size available in each block (always `>0`)
   mi_block_t*           local_free;        // list of deferred free blocks by this thread (migrates to `free`)
 

--- a/test/test-api.c
+++ b/test/test-api.c
@@ -46,6 +46,11 @@ bool test_heap2(void);
 bool test_stl_allocator1(void);
 bool test_stl_allocator2(void);
 
+bool test_stl_heap_allocator1(void);
+bool test_stl_heap_allocator2(void);
+bool test_stl_heap_allocator3(void);
+bool test_stl_heap_allocator4(void);
+
 bool mem_is_zero(uint8_t* p, size_t size) {
   if (p==NULL) return false;
   for (size_t i = 0; i < size; ++i) {
@@ -304,6 +309,11 @@ int main(void) {
   CHECK("stl_allocator1", test_stl_allocator1());
   CHECK("stl_allocator2", test_stl_allocator2());
 
+	CHECK("stl_heap_allocator1", test_stl_heap_allocator1());
+	CHECK("stl_heap_allocator2", test_stl_heap_allocator2());
+	CHECK("stl_heap_allocator3", test_stl_heap_allocator3());
+	CHECK("stl_heap_allocator4", test_stl_heap_allocator4());
+
   // ---------------------------------------------------
   // Done
   // ---------------------------------------------------[]
@@ -353,6 +363,64 @@ bool test_stl_allocator2(void) {
   vec.push_back(some_struct());
   vec.pop_back();
   return vec.size() == 0;
+#else
+  return true;
+#endif
+}
+
+bool test_stl_heap_allocator1(void) {
+#ifdef __cplusplus
+  std::vector<some_struct, mi_heap_stl_allocator<some_struct> > vec;
+  vec.push_back(some_struct());
+  vec.pop_back();
+  return vec.size() == 0;
+#else
+  return true;
+#endif
+}
+
+bool test_stl_heap_allocator2(void) {
+#ifdef __cplusplus
+  std::vector<some_struct, mi_heap_destroy_stl_allocator<some_struct> > vec;
+  vec.push_back(some_struct());
+  vec.pop_back();
+  return vec.size() == 0;
+#else
+  return true;
+#endif
+}
+
+bool test_stl_heap_allocator3(void) {
+#ifdef __cplusplus
+	mi_heap_t* heap = mi_heap_new();
+	bool good = false;
+	{
+		mi_heap_stl_allocator<some_struct> myAlloc(heap);
+		std::vector<some_struct, mi_heap_stl_allocator<some_struct> > vec(myAlloc);
+		vec.push_back(some_struct());
+		vec.pop_back();
+		good = vec.size() == 0;
+	}
+	mi_heap_delete(heap);
+  return good;
+#else
+  return true;
+#endif
+}
+
+bool test_stl_heap_allocator4(void) {
+#ifdef __cplusplus
+	mi_heap_t* heap = mi_heap_new();
+	bool good = false;
+	{
+		mi_heap_destroy_stl_allocator<some_struct> myAlloc(heap);
+		std::vector<some_struct, mi_heap_destroy_stl_allocator<some_struct> > vec(myAlloc);
+		vec.push_back(some_struct());
+		vec.pop_back();
+		good = vec.size() == 0;
+	}
+	mi_heap_destroy(heap);
+  return good;
 #else
   return true;
 #endif


### PR DESCRIPTION
This is just https://github.com/microsoft/mimalloc/pull/864 for dev-slice.