### PR TITLE
Emscripten: Remove no-longer-needed minimum emmalloc alignment

### DIFF
--- a/src/prim/emscripten/prim.c
+++ b/src/prim/emscripten/prim.c
@@ -78,17 +78,10 @@ int _mi_prim_alloc(size_t size, size_t try_alignment, bool commit, bool allow_la
   //       That assumes no one else uses sbrk but us (they could go up,
   //       scribble, and then down), but we could assert on that perhaps.
   *is_zero = false;
-  // emmalloc has some limitations on alignment size.
-  // TODO: Why does mimalloc ask for an align of 4MB? that ends up allocating
-  //       8, which wastes quite a lot for us in wasm. If that is unavoidable,
-  //       we may want to improve emmalloc to support such alignment. See also
-  //       https://github.com/emscripten-core/emscripten/issues/20645
+  // emmalloc has a minimum alignment size.
   #define MIN_EMMALLOC_ALIGN           8
-  #define MAX_EMMALLOC_ALIGN (1024*1024)
   if (try_alignment < MIN_EMMALLOC_ALIGN) {
     try_alignment = MIN_EMMALLOC_ALIGN;
-  } else if (try_alignment > MAX_EMMALLOC_ALIGN) {
-    try_alignment = MAX_EMMALLOC_ALIGN;
   }
   void* p = emmalloc_memalign(try_alignment, size);
   *addr = p;


### PR DESCRIPTION
https://github.com/emscripten-core/emscripten/pull/20704 removed the maximum alignment limit from emmalloc, so we no longer need it in the mimalloc port. Without it, we can properly use the 4GB-aligned pages that mimalloc requests.

(Emscripten-side testing in https://github.com/emscripten-core/emscripten/pull/21905)