### PR TITLE
Build on cygwin

### DIFF
--- a/include/mimalloc/prim.h
+++ b/include/mimalloc/prim.h
@@ -209,6 +209,7 @@ static inline void mi_prim_tls_slot_set(size_t slot, void* value) mi_attr_noexce
 // Nevertheless, it seems needed on older graviton platforms (see issue #851).
 // For now, we only enable this for specific platforms.
 #if !defined(__APPLE__)  /* on apple (M1) the wrong register is read (tpidr_el0 instead of tpidrro_el0) so fall back to TLS slot assembly (<https://github.com/microsoft/mimalloc/issues/343#issuecomment-763272369>)*/ \
+    && !defined(__CYGWIN__) \
     && !defined(MI_LIBC_MUSL) \
     && (!defined(__clang_major__) || __clang_major__ >= 14)  /* older clang versions emit bad code; fall back to using the TLS slot (<https://lore.kernel.org/linux-arm-kernel/202110280952.352F66D8@keescook/T/>) */
   #if    (defined(__GNUC__) && (__GNUC__ >= 7)  && defined(__aarch64__)) /* aarch64 for older gcc versions (issue #851) */ \


### PR DESCRIPTION
```
$ uname -srvmpio
CYGWIN_NT-10.0-22000 3.5.3-1.x86_64 2024-04-03 17:25 UTC x86_64 unknown unknown Cygwin
$ cd /tmp
$ git clone https://github.com/microsoft/mimalloc.git
$ cd mimalloc
$ cmake -DMI_BUILD_STATIC:BOOL=OFF -DMI_BUILD_OBJECT:BOOL=OFF -DMI_INSTALL_TOPLEVEL:BOOL=ON .
$ make VERBOSE=1
:
[  4%] Linking C shared library cygmimalloc-1.dll
/usr/bin/cmake.exe -E cmake_link_script CMakeFiles/mimalloc.dir/link.txt --verbose=1
/usr/bin/cc -O3 -DNDEBUG -shared -Wl,--enable-auto-import -o cygmimalloc-1.dll -Wl,--out-implib,libmimalloc.dll.a -Wl,--major-image-version,1,--minor-image-version,8 CMakeFiles/mimalloc.dir/src/alloc.c.o "CMakeFiles/mimalloc.dir/src/alloc-aligned.c.o" "CMakeFiles/mimalloc.dir/src/alloc-posix.c.o" CMakeFiles/mimalloc.dir/src/arena.c.o CMakeFiles/mimalloc.dir/src/bitmap.c.o CMakeFiles/mimalloc.dir/src/heap.c.o CMakeFiles/mimalloc.dir/src/init.c.o CMakeFiles/mimalloc.dir/src/libc.c.o CMakeFiles/mimalloc.dir/src/options.c.o CMakeFiles/mimalloc.dir/src/os.c.o CMakeFiles/mimalloc.dir/src/page.c.o CMakeFiles/mimalloc.dir/src/random.c.o CMakeFiles/mimalloc.dir/src/segment.c.o "CMakeFiles/mimalloc.dir/src/segment-map.c.o" CMakeFiles/mimalloc.dir/src/stats.c.o CMakeFiles/mimalloc.dir/src/prim/prim.c.o  -lpthread -lrt -latomic
/usr/lib/gcc/x86_64-pc-cygwin/11/../../../../x86_64-pc-cygwin/bin/ld: CMakeFiles/mimalloc.dir/src/alloc.c.o:alloc.c:(.text+0x219): undefined reference to `__builtin_thread_pointer'
/usr/lib/gcc/x86_64-pc-cygwin/11/../../../../x86_64-pc-cygwin/bin/ld: CMakeFiles/mimalloc.dir/src/alloc.c.o:alloc.c:(.text+0x3d9): undefined reference to `__builtin_thread_pointer'
/usr/lib/gcc/x86_64-pc-cygwin/11/../../../../x86_64-pc-cygwin/bin/ld: CMakeFiles/mimalloc.dir/src/alloc.c.o:alloc.c:(.text+0x499): undefined reference to `__builtin_thread_pointer'
/usr/lib/gcc/x86_64-pc-cygwin/11/../../../../x86_64-pc-cygwin/bin/ld: CMakeFiles/mimalloc.dir/src/alloc.c.o:alloc.c:(.text+0x559): undefined reference to `__builtin_thread_pointer'
/usr/lib/gcc/x86_64-pc-cygwin/11/../../../../x86_64-pc-cygwin/bin/ld: CMakeFiles/mimalloc.dir/src/alloc.c.o:alloc.c:(.text+0x619): undefined reference to `__builtin_thread_pointer'
/usr/lib/gcc/x86_64-pc-cygwin/11/../../../../x86_64-pc-cygwin/bin/ld: CMakeFiles/mimalloc.dir/src/alloc.c.o:alloc.c:(.text+0x6d9): more undefined references to `__builtin_thread_pointer' follow
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/mimalloc.dir/build.make:337: cygmimalloc-1.dll] Error 1
make[2]: Leaving directory '/tmp/mimalloc'
make[1]: *** [CMakeFiles/Makefile2:89: CMakeFiles/mimalloc.dir/all] Error 2
make[1]: Leaving directory '/tmp/mimalloc'
make: *** [Makefile:146: all] Error 2
```

After this modification, all tests passed.

```
$ make VERBOSE=1 test
Running tests...
/usr/bin/ctest.exe --force-new-ctest-process
Test project /tmp/mimalloc
    Start 1: test-api
1/3 Test #1: test-api .........................   Passed    2.58 sec
    Start 2: test-api-fill
2/3 Test #2: test-api-fill ....................   Passed    0.06 sec
    Start 3: test-stress
3/3 Test #3: test-stress ......................   Passed    3.63 sec

100% tests passed, 0 tests failed out of 3

Total Test time (real) =   6.27 sec
```