### PR TITLE
Fix mi_cfree function missing certain big allocations

### DIFF
--- a/src/alloc-posix.c
+++ b/src/alloc-posix.c
@@ -47,7 +47,7 @@ mi_decl_nodiscard size_t mi_malloc_good_size(size_t size) mi_attr_noexcept {
 }
 
 void mi_cfree(void* p) mi_attr_noexcept {
-  if (mi_is_in_heap_region(p)) {
+  if (mi_is_in_heap_region(p) || mi_check_owned(p)) {
     mi_free(p);
   }
 }


### PR DESCRIPTION
The way `mi_is_in_heap_region` is implemented right now (see [this](https://github.com/microsoft/mimalloc/blob/master/src/free.c#L112) code) it is possible to 'miss' certain huge allocations going through `mi_cfree`. So we either need to update the segment detection code (so that it is not limited to [e.g. 2GiB on 32-bit platforms](https://github.com/microsoft/mimalloc/blob/master/src/segment-map.c#L24)) or use the more expensive `mi_check_owned` check if we've failed the simpler heap check.