### PR TITLE
feat: Add support for logging to Android logcat

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -12,7 +12,9 @@ terms of the MIT license. A copy of the license can be found in the file
 #include <stdio.h>      // stdin/stdout
 #include <stdlib.h>     // abort
 
-
+#if defined(__ANDROID__)
+#include <android/log.h> // Output to android logcat
+#endif
 
 static long mi_max_error_count   = 16; // stop outputting errors after this (use < 0 for no limit)
 static long mi_max_warning_count = 16; // stop outputting warnings after this (use < 0 for no limit)
@@ -395,6 +397,9 @@ void _mi_verbose_message(const char* fmt, ...) {
   va_list args;
   va_start(args,fmt);
   mi_vfprintf(NULL, NULL, "mimalloc: ", fmt, args);
+#if defined(__ANDROID__)
+  __android_log_vprint(ANDROID_LOG_VERBOSE, "mimalloc", fmt, args);
+#endif
   va_end(args);
 }
 
@@ -404,6 +409,9 @@ static void mi_show_error_message(const char* fmt, va_list args) {
     if (mi_max_error_count >= 0 && (long)mi_atomic_increment_acq_rel(&error_count) > mi_max_error_count) return;
   }
   mi_vfprintf_thread(NULL, NULL, "mimalloc: error: ", fmt, args);
+#if defined(__ANDROID__)
+  __android_log_vprint(ANDROID_LOG_ERROR, "mimalloc", fmt, args);
+#endif
 }
 
 void _mi_warning_message(const char* fmt, ...) {
@@ -414,6 +422,9 @@ void _mi_warning_message(const char* fmt, ...) {
   va_list args;
   va_start(args,fmt);
   mi_vfprintf_thread(NULL, NULL, "mimalloc: warning: ", fmt, args);
+#if defined(__ANDROID__)
+  __android_log_vprint(ANDROID_LOG_WARN, "mimalloc", fmt, args);
+#endif
   va_end(args);
 }
 


### PR DESCRIPTION
On android, especially when using mimalloc in an android application there's not way to check the logs outputed by mimalloc. This PR fixes that by also outputing logging on Android's logcat