### PR TITLE
Fix potential buffer overflow warning

### DIFF
--- a/src/heap.c
+++ b/src/heap.c
@@ -59,7 +59,8 @@ static bool mi_heap_page_is_valid(mi_heap_t* heap, mi_page_queue_t* pq, mi_page_
   MI_UNUSED(pq);
   mi_assert_internal(mi_page_heap(page) == heap);
   mi_segment_t* segment = _mi_page_segment(page);
-  mi_assert_internal(segment->thread_id == heap->thread_id);
+  uintptr_t thread_id = __atomic_load_n(&segment->thread_id, __ATOMIC_RELAXED);
+  mi_assert_internal(thread_id == heap->thread_id);
   mi_assert_expensive(_mi_page_is_valid(page));
   return true;
 }


### PR DESCRIPTION
The compiler gives the warning at:

```
error: '__atomic_load_8' writing 8 bytes into a region of size 0 overflows the destination [-Werror=stringop-overflow=]

In file included from /janus/3p/mimalloc/include/mimalloc/internal.h:17,
                 from /janus/3p/mimalloc/src/heap.c:9:
In function 'mi_heap_page_is_valid',
    inlined from 'mi_heap_page_collect' at /janus/3p/mimalloc/src/heap.c:95:3:
/janus/3p/mimalloc/src/heap.c:62:22: error: '__atomic_load_8' writing 8 bytes into a region of size 0 overflows the destination [-Werror=stringop-overflow=]
   62 |   mi_assert_internal(segment->thread_id == heap->thread_id);
      |                      ^~~~~~~
```

It is detecting a potential buffer overflow when accessing the thread_id in the segment structure. The warning suggests that the compiler believes the thread_id is being accessed in a way that could lead to reading or writing beyond the allocated memory of the structure. Thus this PR ensures that the thread_id is being read in a way that respects atomicity, which prevents the compiler warning.