### PR TITLE
Skip aligned allocation on SV39 MMUs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -343,6 +343,16 @@ if(MINGW)
   add_definitions(-D_WIN32_WINNT=0x600)
 endif()
 
+# Check /proc/cpuinfo for an SV39 MMU and define a constant if one is
+# found. We will want to skip the aligned hinting in that case.
+if (EXISTS /proc/cpuinfo)
+  file(STRINGS /proc/cpuinfo mi_sv39_mmu REGEX "^mmu[ \t]+:[ \t]+sv39$")
+  if (mi_sv39_mmu)
+    MESSAGE( STATUS "SV39 MMU detected" )
+    list(APPEND mi_defines MI_SV39_MMU=1)
+  endif()
+endif()
+
 # extra needed libraries
 
 # we prefer -l<lib> test over `find_library` as sometimes core libraries 

--- a/src/os.c
+++ b/src/os.c
@@ -77,8 +77,10 @@ bool _mi_os_commit(void* addr, size_t size, bool* is_zero, mi_stats_t* tld_stats
 -------------------------------------------------------------- */
 
 // On 64-bit systems, we can do efficient aligned allocation by using
-// the 2TiB to 30TiB area to allocate those.
-#if (MI_INTPTR_SIZE >= 8)
+// the 2TiB to 30TiB area to allocate those. The one exception is on
+// 64-bit RISC-V systems that have an SV39 MMU; there the 256GiB+
+// range (and specifically the 2TiB+ range) will not be usable.
+#if (MI_INTPTR_SIZE >= 8) && (!defined(MI_SV39_MMU) || MI_SV39_MMU == 0)
 static mi_decl_cache_align _Atomic(uintptr_t)aligned_base;
 
 // Return a MI_SEGMENT_SIZE aligned address that is probably available.


### PR DESCRIPTION
An attempt at fixing https://github.com/microsoft/mimalloc/issues/939

The SV39 detection works well enough with my sample size of 1. But I also had to add some extra `#if`s to `mi_os_prim_alloc_aligned()` to avoid the pointless alloc/free. I don't have any 32-bit hardware any more, but this should speed things up there, too.
