### PR TITLE
enforce first null byte in CANARY

### DIFF
--- a/include/mimalloc/types.h
+++ b/include/mimalloc/types.h
@@ -472,6 +472,7 @@ typedef struct mi_padding_s {
   uint32_t canary; // encoded block value to check validity of the padding (in case of overflow)
   uint32_t delta;  // padding bytes before the block. (mi_usable_size(p) - delta == exact allocated bytes)
 } mi_padding_t;
+#define MI_CANARY_MASK    (0xffffff00)
 #define MI_PADDING_SIZE   (sizeof(mi_padding_t))
 #define MI_PADDING_WSIZE  ((MI_PADDING_SIZE + MI_INTPTR_SIZE - 1) / MI_INTPTR_SIZE)
 #else

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -99,7 +99,7 @@ extern inline void* _mi_page_malloc_zero(mi_heap_t* heap, mi_page_t* page, size_
     mi_assert_internal(delta >= 0 && mi_page_usable_block_size(page) >= (size - MI_PADDING_SIZE + delta));
     #endif
     mi_track_mem_defined(padding,sizeof(mi_padding_t));  // note: re-enable since mi_page_usable_block_size may set noaccess
-    padding->canary = (uint32_t)(mi_ptr_encode(page,block,page->keys));
+    padding->canary = (uint32_t)(mi_ptr_encode(page,block,page->keys)) & MI_CANARY_MASK;
     padding->delta  = (uint32_t)(delta);
     #if MI_PADDING_CHECK
     if (!mi_page_is_huge(page)) {


### PR DESCRIPTION
## Problem
Currently it's possible to trivially leak the heap canary if the allocated buffer is fully filled and interpreted as a string.
This is a common programming mistake, especially using POSIX functions that don't enforce null terminated strings (e.g. `strncpy`). 

This potential implementation resolves #951.

## Change
This pull request implements a simple bit mask, that enforces that the LSB (least significant byte of the canary) is a null byte. 

## notes
Sadly this implementation removes one potential byte of entropy for our canary, reducing it from 32bit to 24bit,
but still allows the detection of common one null byte overflows, something that would be lost if the first/last character of padding was turned into a null byte.

This implementation only considers little endianness