### PR TITLE
Fix crash on exit on Android with destroy_on_exit

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -663,9 +663,6 @@ void mi_cdecl _mi_process_done(void) {
   if (process_done) return;
   process_done = true;
 
-  // release any thread specific resources and ensure _mi_thread_done is called on all but the main thread
-  _mi_prim_thread_done_auto_done();
-
   #ifndef MI_SKIP_COLLECT_ON_EXIT
     #if (MI_DEBUG || !defined(MI_SHARED_LIB))
     // free all memory if possible on process exit. This is not needed for a stand-alone process
@@ -683,6 +680,10 @@ void mi_cdecl _mi_process_done(void) {
     _mi_heap_unsafe_destroy_all();     // forcefully release all memory held by all heaps (of this thread only!)
     _mi_arena_unsafe_destroy_all();
   }
+
+  // release any thread specific resources and ensure _mi_thread_done is called on all but the main thread
+  // this must be done after _mi_heap_unsafe_destroy_all, which accesses the default heap
+  _mi_prim_thread_done_auto_done();
 
   if (mi_option_is_enabled(mi_option_show_stats) || mi_option_is_enabled(mi_option_verbose)) {
     mi_stats_print(NULL);


### PR DESCRIPTION
When `mi_option_destroy_on_exit` is set, the call to [`_mi_heap_unsafe_destroy_all`](https://github.com/microsoft/mimalloc/blob/7085b6cec31641fddaca3d40932cda82e91baf07/src/init.c#L683) (which calls [`mi_prim_get_default_heap`](https://github.com/microsoft/mimalloc/blob/7085b6cec31641fddaca3d40932cda82e91baf07/include/mimalloc/prim.h#L356), which in turn calls `pthread_getspecific` with `_mi_heap_default_key`) is made _after_ the call to [`_mi_prim_thread_done_auto_done`](https://github.com/microsoft/mimalloc/blob/7085b6cec31641fddaca3d40932cda82e91baf07/src/init.c#L667) (which calls [`pthread_key_delete`](https://github.com/microsoft/mimalloc/blob/7085b6cec31641fddaca3d40932cda82e91baf07/src/prim/unix/prim.c#L864) with `_mi_heap_default_key`).

It appears that, at least on Android, calling `pthread_getspecific` after `pthread_key_delete` returns a null value, which causes `mi_prim_get_default_heap` to return the empty heap, and [this line](https://github.com/microsoft/mimalloc/blob/7085b6cec31641fddaca3d40932cda82e91baf07/src/heap.c#L202) to crash due to `heap->tld` being null.

This change moves the call to `_mi_prim_thread_done_auto_done` after all of the uses of `mi_prim_get_default_heap`, so accessing the default heap is possible.