### PR TITLE
Free segment map when destroy_on_exit is set

### DIFF
--- a/include/mimalloc/internal.h
+++ b/include/mimalloc/internal.h
@@ -164,6 +164,7 @@ void          _mi_arena_field_cursor_done(mi_arena_field_cursor_t* current);
 // "segment-map.c"
 void        _mi_segment_map_allocated_at(const mi_segment_t* segment);
 void        _mi_segment_map_freed_at(const mi_segment_t* segment);
+void        _mi_segment_map_destroy(void);
 
 // "segment.c"
 mi_page_t*  _mi_segment_page_alloc(mi_heap_t* heap, size_t block_size, size_t page_alignment, mi_segments_tld_t* tld);

--- a/src/init.c
+++ b/src/init.c
@@ -682,6 +682,7 @@ void mi_cdecl _mi_process_done(void) {
     mi_collect(true /* force */);
     _mi_heap_unsafe_destroy_all();     // forcefully release all memory held by all heaps (of this thread only!)
     _mi_arena_unsafe_destroy_all();
+    _mi_segment_map_destroy();
   }
 
   if (mi_option_is_enabled(mi_option_show_stats) || mi_option_is_enabled(mi_option_verbose)) {

--- a/src/segment-map.c
+++ b/src/segment-map.c
@@ -57,6 +57,7 @@ static mi_segmap_part_t* mi_segment_map_index_of(const mi_segment_t* segment, bo
     mi_memid_t memid;
     part = (mi_segmap_part_t*)_mi_os_alloc(sizeof(mi_segmap_part_t), &memid);
     if (part == NULL) return NULL;
+    part->memid = memid;
     mi_segmap_part_t* expected = NULL;
     if (!mi_atomic_cas_ptr_strong_release(mi_segmap_part_t, &mi_segment_map[segindex], &expected, part)) {
       _mi_os_free(part, sizeof(mi_segmap_part_t), memid);
@@ -123,4 +124,13 @@ static bool mi_is_valid_pointer(const void* p) {
 
 mi_decl_nodiscard mi_decl_export bool mi_is_in_heap_region(const void* p) mi_attr_noexcept {
   return mi_is_valid_pointer(p);
+}
+
+void _mi_segment_map_destroy(void) {
+  for (size_t i = 0; i < MI_SEGMENT_MAP_MAX_PARTS; i++) {
+    mi_segmap_part_t* part = mi_segment_map[i];
+    if (part != NULL) {
+      _mi_os_free(part, sizeof(mi_segmap_part_t), part->memid);
+    }
+  }
 }


### PR DESCRIPTION
The segment map was never being freed, even when `destroy_on_exit` is true. We have a use case where we need all OS memory allocated by a shared library to be freed when the library is unloaded, and we noticed that the segment map parts were never freed.