### PR TITLE
fixed unnecessary set_specific in _mi_heap_set_default_direct

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -537,14 +537,13 @@ void _mi_heap_set_default_direct(mi_heap_t* heap)  {
   #elif defined(MI_TLS_PTHREAD_SLOT_OFS)
   *mi_prim_tls_pthread_heap_slot() = heap;
   #elif defined(MI_TLS_PTHREAD)
+  _mi_prim_thread_associate_default_heap(heap);
   // we use _mi_heap_default_key
   #else
   _mi_heap_default = heap;
   #endif
 
-  // ensure the default heap is passed to `_mi_thread_done`
-  // setting to a non-NULL value also ensures `mi_thread_done` is called.
-  _mi_prim_thread_associate_default_heap(heap);
+
 }
 
 


### PR DESCRIPTION
an unnecessary call to mi_prim_thread_associate_default_heap is made even if MI_TLS_PTHREAD is not defined. This causes unnecessary problems for applications that use separate linker namespaces as pthread_keys are bugged for those applications.