### PR TITLE
fix overflow on arm32

### DIFF
--- a/src/segment-map.c
+++ b/src/segment-map.c
@@ -25,16 +25,11 @@ terms of the MIT license. A copy of the license can be found in the file
 #define MI_SEGMENT_MAP_MAX_ADDRESS    (UINT32_MAX)
 #endif
 
-#define MI_SEGMENT_MAP_PART_SIZE      (MI_INTPTR_SIZE*MI_KiB - 128)      // 128 > sizeof(mi_memid_t) ! 
-#define MI_SEGMENT_MAP_PART_BITS      (8*MI_SEGMENT_MAP_PART_SIZE)
-#define MI_SEGMENT_MAP_PART_ENTRIES   (MI_SEGMENT_MAP_PART_SIZE / MI_INTPTR_SIZE)
-#define MI_SEGMENT_MAP_PART_BIT_SPAN  (MI_SEGMENT_ALIGN)
+#define MI_SEGMENT_MAP_PART_SIZE                                               \
+  (MI_INTPTR_SIZE * MI_KiB - 128) // 128 > sizeof(mi_memid_t) !
+#define MI_SEGMENT_MAP_PART_ENTRIES (MI_SEGMENT_MAP_PART_SIZE / MI_INTPTR_SIZE)
 
-#if (MI_SEGMENT_PART_BITS < (MI_SEGMENT_MAP_MAX_ADDRESS / MI_SEGMENT_MAP_PART_BIT_SPAN)) // prevent overflow on 32-bit (issue #1017)
-#define MI_SEGMENT_MAP_PART_SPAN      (MI_SEGMENT_MAP_PART_BITS * MI_SEGMENT_MAP_PART_BIT_SPAN)
-#else
-#define MI_SEGMENT_MAP_PART_SPAN      MI_SEGMENT_MAP_MAX_ADDRESS
-#endif
+#define MI_SEGMENT_MAP_PART_SPAN (MI_SEGMENT_MAP_PART_SIZE * MI_SEGMENT_ALIGN)
 
 #define MI_SEGMENT_MAP_MAX_PARTS      ((MI_SEGMENT_MAP_MAX_ADDRESS / MI_SEGMENT_MAP_PART_SPAN) + 1)
 
@@ -73,7 +68,7 @@ static mi_segmap_part_t* mi_segment_map_index_of(const mi_segment_t* segment, bo
   }
   mi_assert(part != NULL);
   const uintptr_t offset = ((uintptr_t)segment) % MI_SEGMENT_MAP_PART_SPAN;
-  const uintptr_t bitofs = offset / MI_SEGMENT_MAP_PART_BIT_SPAN;
+  const uintptr_t bitofs = offset / MI_SEGMENT_ALIGN;
   *idx = bitofs / MI_INTPTR_BITS;
   *bitidx = bitofs % MI_INTPTR_BITS;
   return part;


### PR DESCRIPTION
Previously we were dividing MI_SEGMENT_MAP_PART_SIZE (in bytes) by (MI_SEGMENT_MAP_PART_BITS * MI_SEGMENT_MAP_PART_BIT_SPAN) (in bits). Not to say that it looks incorrect, it also results in UB when MI_SEGMENT_MAP_PART_SIZE is 2^32 (32bit system).
Fix for the https://github.com/microsoft/mimalloc/issues/1017