### PR TITLE
improve MacOS interposes to make mimalloc compile for older MacOS

### DIFF
--- a/src/alloc-override.c
+++ b/src/alloc-override.c
@@ -77,18 +77,12 @@ typedef void* mi_nothrow_t;
     MI_INTERPOSE_MI(calloc),
     MI_INTERPOSE_MI(realloc),
     MI_INTERPOSE_MI(strdup),
-    #if defined(MAC_OS_X_VERSION_10_7) && MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_7
-    MI_INTERPOSE_MI(strndup),
-    #endif
     MI_INTERPOSE_MI(realpath),
     MI_INTERPOSE_MI(posix_memalign),
     MI_INTERPOSE_MI(reallocf),
     MI_INTERPOSE_MI(valloc),
     MI_INTERPOSE_FUN(malloc_size,mi_malloc_size_checked),
     MI_INTERPOSE_MI(malloc_good_size),
-    #if defined(MAC_OS_X_VERSION_10_15) && MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_15
-    MI_INTERPOSE_MI(aligned_alloc),
-    #endif
     #ifdef MI_OSX_ZONE
     // we interpose malloc_default_zone in alloc-override-osx.c so we can use mi_free safely
     MI_INTERPOSE_MI(free),
@@ -98,6 +92,15 @@ typedef void* mi_nothrow_t;
     MI_INTERPOSE_FUN(free,mi_cfree), // use safe free that checks if pointers are from us
     MI_INTERPOSE_FUN(vfree,mi_cfree),
     #endif
+  };
+  __attribute__((used)) static struct mi_interpose_s _mi_interposes_10_7[]
+  __attribute__((section("__DATA, __interpose"))) __OSX_AVAILABLE(10.7) = {
+      MI_INTERPOSE_MI(strndup),
+};
+
+  __attribute__((used)) static struct mi_interpose_s _mi_interposes_10_15[]
+      __attribute__((section("__DATA, __interpose"))) __OSX_AVAILABLE(10.15) = {
+          MI_INTERPOSE_MI(aligned_alloc),
   };
 
   #ifdef __cplusplus


### PR DESCRIPTION
I've got a failure while trying to compile with "-mmacosx-version-min=10.7" since MAC_OS_X_VERSION_MAX_ALLOWED is greater than MAC_OS_X_VERSION_10_15 but still we can't use `aligned_alloc` since of the lower bound (10.7). I'm not sure about internal details of how `__OSX_AVAILABLE` works, but my hope is the it would only make this interpose available starting from the OS version specified. Also, it helps me to compile mimalloc with "-mmacosx-version-min=10.7".