### PR TITLE
fix recursion in TLS init on Android

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -425,14 +425,14 @@ static mi_decl_noinline void mi_recurse_exit_prim(void) {
 }
 
 static bool mi_recurse_enter(void) {
-  #if defined(__APPLE__) || defined(MI_TLS_RECURSE_GUARD)
+  #if defined(__APPLE__) || defined(__ANDROID__) || defined(MI_TLS_RECURSE_GUARD)
   if (_mi_preloading()) return false;
   #endif
   return mi_recurse_enter_prim();
 }
 
 static void mi_recurse_exit(void) {
-  #if defined(__APPLE__) || defined(MI_TLS_RECURSE_GUARD)
+  #if defined(__APPLE__) || defined(__ANDROID__) || defined(MI_TLS_RECURSE_GUARD)
   if (_mi_preloading()) return;
   #endif
   mi_recurse_exit_prim();


### PR DESCRIPTION
I'm hitting infinite recursion here when trying to run statically linked mimalloc from `dev3` with `MI_DEBUG_FULL=ON`+ `MI_CHECK_FULL=ON` on Android.
Attaching top of the callstack:
```
_mi_heap_main_get (mimalloc/src/init.c:272)
mi_prim_get_default_heap (mimalloc/include/mimalloc/prim.h:411)
mi_malloc (mimalloc/src/alloc.c:208)
__emutls_get_address (@__emutls_get_address:65)
mi_recurse_enter_prim (mimalloc/src/options.c:421)
mi_recurse_enter (mimalloc/src/options.c:434)
mi_vfprintf (mimalloc/src/options.c:463)
_mi_fprintf (mimalloc/src/options.c:472)
_mi_assert_fail (mimalloc/src/options.c:539)
_mi_page_map_register (mimalloc/src/page-map.c:284)
mi_arenas_page_alloc_fresh (mimalloc/src/arena.c:703)
mi_arenas_page_regular_alloc (mimalloc/src/arena.c:727)
_mi_arenas_page_alloc (mimalloc/src/arena.c:766)
mi_page_fresh_alloc (mimalloc/src/page.c:305)
mi_page_fresh (mimalloc/src/page.c:335)
mi_page_queue_find_free_ex (mimalloc/src/page.c:807)
mi_find_free_page (mimalloc/src/page.c:848)
mi_find_page (mimalloc/src/page.c:929)
_mi_malloc_generic (mimalloc/src/page.c:965)
_mi_page_malloc_zero (mimalloc/src/alloc.c:42)
mi_heap_malloc_small_zero (mimalloc/src/alloc.c:151)
_mi_heap_malloc_zero_ex (mimalloc/src/alloc.c:176)
_mi_heap_malloc_zero (mimalloc/src/alloc.c:200)
mi_heap_malloc (mimalloc/src/alloc.c:204)
mi_malloc (mimalloc/src/alloc.c:208)
__emutls_get_address (@__emutls_get_address:65)
mi_recurse_enter_prim (mimalloc/src/options.c:421)
mi_recurse_enter (mimalloc/src/options.c:434)
mi_vfprintf (mimalloc/src/options.c:463)
_mi_fprintf (mimalloc/src/options.c:472)
_mi_assert_fail (mimalloc/src/options.c:539)
_mi_page_map_register (mimalloc/src/page-map.c:284)
mi_arenas_page_alloc_fresh (mimalloc/src/arena.c:703)
mi_arenas_page_regular_alloc (mimalloc/src/arena.c:727)
_mi_arenas_page_alloc (mimalloc/src/arena.c:766)
mi_page_fresh_alloc (mimalloc/src/page.c:305)
mi_page_fresh (mimalloc/src/page.c:335)
mi_page_queue_find_free_ex (mimalloc/src/page.c:807)
mi_find_free_page (mimalloc/src/page.c:848)
mi_find_page (mimalloc/src/page.c:929)
```