### PR TITLE
unix: only include linux headers on glibc

### DIFF
--- a/src/prim/unix/prim.c
+++ b/src/prim/unix/prim.c
@@ -31,11 +31,11 @@ terms of the MIT license. A copy of the license can be found in the file
 
 #if defined(__linux__)
   #include <features.h>
-  #include <linux/prctl.h>  // PR_SET_VMA
   //#if defined(MI_NO_THP)
   #include <sys/prctl.h>    // THP disable
   //#endif
   #if defined(__GLIBC__)
+  #include <linux/prctl.h>  // PR_SET_VMA
   #include <linux/mman.h>   // linux mmap flags
   #else
   #include <sys/mman.h>


### PR DESCRIPTION
On musl-libc the required types for `prctl` are defined in `sys/prctl.h` and including `linux/prctl.h` fails either because the file does not exist or because it redefines the types.