### PR TITLE
fix: build on newer linux distributions

### DIFF
--- a/src/prim/unix/prim.c
+++ b/src/prim/unix/prim.c
@@ -31,10 +31,13 @@ terms of the MIT license. A copy of the license can be found in the file
 
 #if defined(__linux__)
   #include <features.h>
-  #include <linux/prctl.h>  // PR_SET_VMA
-  //#if defined(MI_NO_THP)
   #include <sys/prctl.h>    // THP disable
-  //#endif
+  
+  // Pick up missing definitions from linux headers.
+  #if !defined(PR_SET_VMA)
+    #include <linux/prctl.h>  // PR_SET_VMA
+  #endif
+
   #if defined(__GLIBC__)
   #include <linux/mman.h>   // linux mmap flags
   #else


### PR DESCRIPTION
Newer linux distributions correctly define PR_XXX constants. For older ones we should include <linux/prctl.h> explicitly.

Fixes https://github.com/microsoft/mimalloc/issues/1065