### PR TITLE
dev3: do not touch uncommitted memory

### DIFF
--- a/src/arena.c
+++ b/src/arena.c
@@ -677,7 +677,10 @@ static mi_page_t* mi_arenas_page_alloc_fresh(size_t slice_count, size_t block_si
     commit_size = _mi_align_up(block_start + block_size, MI_PAGE_MIN_COMMIT_SIZE);
     if (commit_size > page_noguard_size) { commit_size = page_noguard_size; }
     bool is_zero;
-    mi_arena_commit( mi_memid_arena(memid), page, commit_size, &is_zero, 0);
+    if (!mi_arena_commit( mi_memid_arena(memid), page, commit_size, &is_zero, 0)) {
+        mi_os_prim_free(p, commit_size, commit_size);
+        return NULL;
+    }
     if (!memid.initially_zero && !is_zero) {
       _mi_memzero_aligned(page, commit_size);
     }

--- a/src/arena.c
+++ b/src/arena.c
@@ -677,9 +677,9 @@ static mi_page_t* mi_arenas_page_alloc_fresh(size_t slice_count, size_t block_si
     commit_size = _mi_align_up(block_start + block_size, MI_PAGE_MIN_COMMIT_SIZE);
     if (commit_size > page_noguard_size) { commit_size = page_noguard_size; }
     bool is_zero;
-    if (!mi_arena_commit( mi_memid_arena(memid), page, commit_size, &is_zero, 0)) {
-        mi_os_prim_free(p, commit_size, commit_size);
-        return NULL;
+    if (!mi_arena_commit(mi_memid_arena(memid), page, commit_size, &is_zero,
+                         0)) {
+      return NULL;
     }
     if (!memid.initially_zero && !is_zero) {
       _mi_memzero_aligned(page, commit_size);

--- a/src/os.c
+++ b/src/os.c
@@ -310,7 +310,7 @@ static void* mi_os_prim_alloc_aligned(size_t size, size_t alignment, bool commit
       // explicitly commit only the aligned part
       if (commit) {
         if (!_mi_os_commit(p, size, NULL)) {
-          mi_os_prim_free(p, size, size);
+          mi_os_prim_free(*base, size, size);
           return NULL;
         }
       }

--- a/src/os.c
+++ b/src/os.c
@@ -309,7 +309,10 @@ static void* mi_os_prim_alloc_aligned(size_t size, size_t alignment, bool commit
 
       // explicitly commit only the aligned part
       if (commit) {
-        _mi_os_commit(p, size, NULL);
+        if (!_mi_os_commit(p, size, NULL)) {
+          mi_os_prim_free(p, size, size);
+          return NULL;
+        }
       }
     }
     else  { // mmap can free inside an allocation


### PR DESCRIPTION
Sometimes, under high memory pressure situation, VirtualAlloc can fail to commit memory. In such cases, we should not touch such memory, but rather return `NULL` ptr so we try to `mi_heap_collect` and recover.
It actually fixes several crashes which we observed under high memory pressure. I'm not sure if it will help us (depends on how much `mi_heap_collect` can actually collect here:
```
  // find (or allocate) a page of the right size
  mi_page_t* page = mi_find_page(heap, size, huge_alignment);
  if mi_unlikely(page == NULL) { // first time out of memory, try to collect and retry the allocation once more
    mi_heap_collect(heap, true /* force? */);
    page = mi_find_page(heap, size, huge_alignment);
  }
  ```
but at least we won't touch uncommitted memory and get killed by OS.

Also, seems to be easy to repro if you just try allocate too much memory, like:
```
    for (int i = 0; i < 1000; ++ i) {
         malloc(4294967296);
    }
```
on my system it fails when ~`i=32`.