### PR TITLE
Fixes https://github.com/microsoft/mimalloc/issues/1158.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -734,6 +734,7 @@ if (MI_BUILD_TESTS)
       target_link_libraries(mimalloc-test-stress-dynamic PRIVATE mimalloc ${mi_libraries})  # link mi_version
       add_test(NAME test-stress-dynamic COMMAND ${CMAKE_COMMAND} -E env MIMALLOC_VERBOSE=1 $<TARGET_FILE:mimalloc-test-stress-dynamic>)
     else()
+      target_link_libraries(mimalloc-test-stress-dynamic PRIVATE mimalloc ${mi_libraries})
       if(APPLE)
         set(LD_PRELOAD "DYLD_INSERT_LIBRARIES")
       else()


### PR DESCRIPTION
One-liner, adds libraries to link step for stress test. Verified that this fixes https://github.com/microsoft/mimalloc/issues/1158. Also tested on Mac and Amazon Linux 2023.

## Before:

```
[ 95%] Built target mimalloc-test-stress
[ 97%] Building C object CMakeFiles/mimalloc-test-stress-dynamic.dir/test/test-stress.c.o
[100%] Linking C executable mimalloc-test-stress-dynamic
CMakeFiles/mimalloc-test-stress-dynamic.dir/test/test-stress.c.o: In function `main':
test-stress.c:(.text.startup+0x106): undefined reference to `pthread_create'
test-stress.c:(.text.startup+0x12c): undefined reference to `pthread_join'
collect2: error: ld returned 1 exit status
make[2]: *** [mimalloc-test-stress-dynamic] Error 1
make[1]: *** [CMakeFiles/mimalloc-test-stress-dynamic.dir/all] Error 2
make: *** [all] Error 2
```

## After:

```
[ 95%] Linking C executable mimalloc-test-stress
[ 95%] Built target mimalloc-test-stress
[ 97%] Building C object CMakeFiles/mimalloc-test-stress-dynamic.dir/test/test-stress.c.o
[100%] Linking C executable mimalloc-test-stress-dynamic
[100%] Built target mimalloc-test-stress-dynamic
```
