### PR TITLE
Drop version requirement in test/CMakeLists.txt

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,8 +16,8 @@ if (NOT CMAKE_BUILD_TYPE)
 endif()
 
 # Import mimalloc (if installed)
-find_package(mimalloc 2.2 CONFIG REQUIRED)
-message(STATUS "Found mimalloc installed at: ${MIMALLOC_LIBRARY_DIR} (${MIMALLOC_VERSION_DIR})")
+find_package(mimalloc CONFIG REQUIRED)
+message(STATUS "Found mimalloc ${mimalloc_VERSION} installed at: ${MIMALLOC_LIBRARY_DIR} (${MIMALLOC_VERSION_DIR})")
 
 
 # link with a dynamic shared library


### PR DESCRIPTION
The required versioned isn't synced with the installed version, making it impossible to run the stand-alone tests without patching the source. OTOH CMake lets the user inject the desired config location, and the found version can be reported.