### PR TITLE
Fix mi_heap_free with arena

### DIFF
--- a/src/heap.c
+++ b/src/heap.c
@@ -305,7 +305,10 @@ static void mi_heap_free(mi_heap_t* heap, bool do_free_mem) {
 
   // and free the used memory
   if (do_free_mem) {
-    _mi_meta_free(heap, sizeof(*heap), heap->memid);
+    const size_t actual_size = (heap->memid.memkind == MI_MEM_ARENA
+                                 ? (size_t)heap->memid.mem.arena.slice_count * MI_ARENA_SLICE_SIZE
+                                 : sizeof(*heap));
+    _mi_meta_free(heap, actual_size, heap->memid);
   }
 }
 

--- a/test/test-api.c
+++ b/test/test-api.c
@@ -43,6 +43,8 @@ we therefore test the API over various inputs. Please add more tests :-)
 // ---------------------------------------------------------------------------
 bool test_heap1(void);
 bool test_heap2(void);
+bool test_heap_arena_destroy(void);
+bool test_heap_arena_delete(void);
 bool test_stl_allocator1(void);
 bool test_stl_allocator2(void);
 
@@ -339,6 +341,8 @@ int main(void) {
   // ---------------------------------------------------
   CHECK("heap_destroy", test_heap1());
   CHECK("heap_delete", test_heap2());
+  CHECK("heap_arena_destroy", test_heap_arena_destroy());
+  CHECK("heap_arena_delete", test_heap_arena_delete());
 
   //mi_stats_print(NULL);
 
@@ -388,6 +392,32 @@ bool test_heap2(void) {
   *p1 = 42;
   mi_free(p1);
   mi_free(p2);
+  return true;
+}
+
+bool test_heap_arena_destroy(void) {
+  mi_arena_id_t arena_id = NULL;
+  if (mi_reserve_os_memory_ex(32 * 1024 * 1024, true, false, true, &arena_id) != 0) {
+    return false;
+  }
+  mi_heap_t* heap = mi_heap_new_ex(0, true, arena_id);
+  if (heap == NULL) {
+    return false;
+  }
+  mi_heap_destroy(heap);
+  return true;
+}
+
+bool test_heap_arena_delete(void) {
+  mi_arena_id_t arena_id = NULL;
+  if (mi_reserve_os_memory_ex(32 * 1024 * 1024, true, false, true, &arena_id) != 0) {
+    return false;
+  }
+  mi_heap_t* heap = mi_heap_new_ex(0, true, arena_id);
+  if (heap == NULL) {
+    return false;
+  }
+  mi_heap_delete(heap);
   return true;
 }
 


### PR DESCRIPTION
Without this fix, the test returns:
```
test: heap_arena_destroy...  mimalloc: assertion failed: at "/mimalloc/src/arena.c":1009, _mi_arenas_free
  assertion: "(size%MI_ARENA_SLICE_SIZE)==0"
Aborted                    (core dumped) build/debug/mimalloc-test-api
```

Added tests for both `mi_heap_delete` and `mi_heap_destroy` (with `allow_destroy` set to `true`).