### PR TITLE
Clamp reserve_at to (-1, INT_MAX)

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -627,7 +627,7 @@ void mi_process_init(void) mi_attr_noexcept {
 
   if (mi_option_is_enabled(mi_option_reserve_huge_os_pages)) {
     size_t pages = mi_option_get_clamp(mi_option_reserve_huge_os_pages, 0, 128*1024);
-    long reserve_at = mi_option_get(mi_option_reserve_huge_os_pages_at);
+    int reserve_at  = (int)mi_option_get_clamp(mi_option_reserve_huge_os_pages_at, -1, INT_MAX);
     if (reserve_at != -1) {
       mi_reserve_huge_os_pages_at(pages, reserve_at, pages*500);
     } else {


### PR DESCRIPTION
Clamp reserve_at to int in order to comply with signature of second parameter of mi_reserve_huge_os_pages_at(). Closes #1148.