### PR TITLE
Fix crash in pthread_tsd_cleanup on macOS ARM64 (#1177)

### DIFF
--- a/include/mimalloc/internal.h
+++ b/include/mimalloc/internal.h
@@ -578,7 +578,9 @@ static inline mi_page_t* _mi_checked_ptr_page(const void* p) {
   const size_t idx = _mi_page_map_index(p, &sub_idx);
   mi_submap_t const sub = _mi_page_map[idx];
   if mi_unlikely(sub == NULL) return (mi_page_t*)&_mi_page_empty;
-  return sub[sub_idx];
+  mi_page_t* const page = sub[sub_idx];
+  if mi_unlikely(page == NULL) return (mi_page_t*)&_mi_page_empty;
+  return page;
 }
 
 #endif


### PR DESCRIPTION
Fixes #1177

On macOS ARM64, freeing memory during thread exit can crash when `thread_local` C++ objects are involved. The issue is that `_mi_checked_ptr_page` checks for `sub == NULL` but not for `sub[sub_idx] == NULL` - commit 515047b fixed the first case but missed the second.

This adds the missing NULL check so both cases return `_mi_page_empty` consistently.