### PR TITLE
Fix conditional buffer overflow caused by undersized `mi_stat_s::page_bins` array

### DIFF
--- a/include/mimalloc-stats.h
+++ b/include/mimalloc-stats.h
@@ -81,8 +81,8 @@ typedef struct mi_stats_s
   mi_stat_counter_t _stat_counter_reserved[4];
 
   // size segregated statistics
-  mi_stat_count_t   malloc_bins[MI_BIN_HUGE+1];   // allocation per size bin
-  mi_stat_count_t   page_bins[MI_BIN_HUGE+1];     // pages allocated per size bin
+  mi_stat_count_t   malloc_bins[MI_BIN_FULL+1];   // allocation per size bin
+  mi_stat_count_t   page_bins[MI_BIN_FULL+1];     // pages allocated per size bin
 } mi_stats_t;
 
 #undef MI_STAT_COUNT


### PR DESCRIPTION
Fix a conditional overflow where the undersized `mi_stat_s::page_bins` array (sized `MI_BIN_HUGE+1`) overflows if `_mi_page_bin()` returns a value larger than `MI_BIN_HUGE`. This behavior most commonly occurs when a large amount of temporary `mi_heap` objects are created/destroyed.

See [this issue](https://github.com/microsoft/mimalloc/issues/1146) for more info on the crash/UB.