### PR TITLE
Avoid "‘always_inline’ function might not be inlinable" warning

### DIFF
--- a/include/mimalloc/internal.h
+++ b/include/mimalloc/internal.h
@@ -42,7 +42,7 @@ terms of the MIT license. A copy of the license can be found in the file
 #define mi_decl_cold
 #elif (defined(__GNUC__) && (__GNUC__ >= 3)) || defined(__clang__) // includes clang and icc
 #if !MI_TRACK_ASAN
-#define mi_decl_forceinline     __attribute__((always_inline))
+#define mi_decl_forceinline     __attribute__((always_inline)) inline
 #else
 #define mi_decl_forceinline     inline
 #endif


### PR DESCRIPTION
Building with MI_OVERRIDE=OFF on gcc 15.2 generates the warning:

    ‘always_inline’ function might not be inlinable unless also declared ‘inline’

on some uses of `mi_decl_forceinline`.

Fix it by following the suggestion and add `inline` to the gcc definition of `mi_decl_forceinline`.