### PR TITLE
Replaced WFE instruction with ISB in mi_atomic_yield on ARM64

### DIFF
--- a/include/mimalloc/atomic.h
+++ b/include/mimalloc/atomic.h
@@ -382,7 +382,7 @@ static inline void mi_atomic_yield(void) {
 }
 #elif defined(__aarch64__)
 static inline void mi_atomic_yield(void) {
-  __asm__ volatile("wfe");
+  __asm__ volatile("isb");
 }
 #elif defined(__arm__)
 #if __ARM_ARCH >= 7


### PR DESCRIPTION
Replaced WFE instruction with ISB in mi_atomic_yield on ARM64 for non Windows as it significantly improves performance.
Also on one closed platform I ported mimalloc to, WFE resulted in an application freeze, because no even was generated to wake threads that were waiting with WFE