### PR TITLE
Fix Android build error with mi_atomic_storei64_release argument type mismatching

### DIFF
--- a/src/arena.c
+++ b/src/arena.c
@@ -648,7 +648,7 @@ static void mi_arenas_try_purge( bool force, bool visit_all )
     }
     if (all_visited) {
       // all arena's were visited and purged: reset global expire
-      mi_atomic_storei64_release(&mi_arenas_purge_expire, 0);
+      mi_atomic_storei64_release(&mi_arenas_purge_expire, (mi_msecs_t)0);
     }
   }
 }


### PR DESCRIPTION
Resolves this compile error. Fix inspired by https://github.com/microsoft/mimalloc/blob/dev3/src/arena.c#L2059
```
Error:   /home/runner/work/Cataclysm-DDA/Cataclysm-DDA/android/app/jni/src/../../../../src/third-party/mimalloc/arena.c:651:7: error: no matching function for call to 'atomic_store_explicit'
        mi_atomic_storei64_release(&mi_arenas_purge_expire, 0);
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  /home/runner/work/Cataclysm-DDA/Cataclysm-DDA/android/app/jni/src/../../../../src/third-party/mimalloc/mimalloc/atomic.h:148:49: note: expanded from macro 'mi_atomic_storei64_release'
  #define mi_atomic_storei64_release(p,x)         mi_atomic(store_explicit)(p,x,mi_memory_order(release))
                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~
  /home/runner/work/Cataclysm-DDA/Cataclysm-DDA/android/app/jni/src/../../../../src/third-party/mimalloc/mimalloc/atomic.h:35:35: note: expanded from macro 'mi_atomic'
  #define  mi_atomic(name)          std::atomic_##name
                                    ^~~~~~~~~~~~~~~~~~
  /usr/local/lib/android/sdk/ndk/25.2.9519653/sources/cxx-stl/llvm-libc++/include/atomic:1890:1: note: candidate template ignored: deduced conflicting types for parameter '_Tp' ('long' vs. 'int')
  atomic_store_explicit(volatile atomic<_Tp>* __o, _Tp __d, memory_order __m) _NOEXCEPT
  ^
  /usr/local/lib/android/sdk/ndk/25.2.9519653/sources/cxx-stl/llvm-libc++/include/atomic:1899:1: note: candidate template ignored: deduced conflicting types for parameter '_Tp' ('long' vs. 'int')
  atomic_store_explicit(atomic<_Tp>* __o, _Tp __d, memory_order __m) _NOEXCEPT
  ^
  /usr/local/lib/android/sdk/ndk/25.2.9519653/sources/cxx-stl/llvm-libc++/include/memory:5138:1: note: candidate template ignored: could not match 'shared_ptr' against 'atomic'
  atomic_store_explicit(shared_ptr<_Tp>* __p, shared_ptr<_Tp> __r, memory_order)
  ^
  1 error generated.
  ```