### PR TITLE
Fix Android compilation errors on dev3 from atomic operation int type mismatches

### DIFF
--- a/include/mimalloc/internal.h
+++ b/include/mimalloc/internal.h
@@ -844,12 +844,12 @@ static inline bool mi_page_is_abandoned_mapped(const mi_page_t* page) {
 
 static inline void mi_page_set_abandoned_mapped(mi_page_t* page) {
   mi_assert_internal(mi_page_is_abandoned(page));
-  mi_atomic_or_relaxed(&page->xthread_id, MI_THREADID_ABANDONED_MAPPED);
+  mi_atomic_or_relaxed(&page->xthread_id, (mi_threadid_t)MI_THREADID_ABANDONED_MAPPED);
 }
 
 static inline void mi_page_clear_abandoned_mapped(mi_page_t* page) {
   mi_assert_internal(mi_page_is_abandoned_mapped(page));
-  mi_atomic_and_relaxed(&page->xthread_id, MI_PAGE_FLAG_MASK);
+  mi_atomic_and_relaxed(&page->xthread_id, (mi_threadid_t)MI_PAGE_FLAG_MASK);
 }
 
 
@@ -907,7 +907,7 @@ static inline bool mi_page_is_owned(const mi_page_t* page) {
 
 // get ownership; returns true if the page was not owned before.
 static inline bool mi_page_claim_ownership(mi_page_t* page) {
-  const uintptr_t old = mi_atomic_or_acq_rel(&page->xthread_free, 1);
+  const uintptr_t old = mi_atomic_or_acq_rel(&page->xthread_free, (uintptr_t)1);
   return ((old&1)==0);
 }
 

--- a/src/arena.c
+++ b/src/arena.c
@@ -1262,7 +1262,7 @@ static void mi_arenas_unsafe_destroy(mi_subproc_t* subproc) {
   }
   // try to lower the max arena.
   size_t expected = arena_count;
-  mi_atomic_cas_strong_acq_rel(&subproc->arena_count, &expected, 0);
+  mi_atomic_cas_strong_acq_rel(&subproc->arena_count, &expected, (size_t)0);
 }
 
 
@@ -2020,7 +2020,7 @@ static void mi_arenas_try_purge(bool force, bool visit_all, mi_subproc_t* subpro
       }
     }
     if (all_visited && !any_purged) {
-      mi_atomic_storei64_release(&subproc->purge_expire, 0);
+      mi_atomic_storei64_release(&subproc->purge_expire, (mi_msecs_t)0);
     }
   }
 }

--- a/src/bitmap.c
+++ b/src/bitmap.c
@@ -1428,7 +1428,7 @@ bool _mi_bitmap_forall_setc_ranges(mi_bitmap_t* bitmap, mi_forall_set_fun_t* vis
       mi_bchunk_t* const chunk = &bitmap->chunks[chunk_idx];
       for (size_t j = 0; j < MI_BCHUNK_FIELDS; j++) {
         const size_t base_idx = (chunk_idx*MI_BCHUNK_BITS) + (j*MI_BFIELD_BITS);
-        mi_bfield_t b = mi_atomic_exchange_relaxed(&chunk->bfields[j], 0);
+        mi_bfield_t b = mi_atomic_exchange_relaxed(&chunk->bfields[j], (mi_bfield_t)0);
 #if MI_DEBUG > 1
         const size_t bpopcount = mi_popcount(b);
         size_t rngcount = 0;
@@ -1481,7 +1481,7 @@ bool _mi_bitmap_forall_setc_rangesn(mi_bitmap_t* bitmap, size_t rngslices, mi_fo
       mi_bchunk_t* const chunk = &bitmap->chunks[chunk_idx];
       for (size_t j = 0; j < MI_BCHUNK_FIELDS; j++) {
         const size_t base_idx = (chunk_idx*MI_BCHUNK_BITS) + (j*MI_BFIELD_BITS);
-        mi_bfield_t b = mi_atomic_exchange_relaxed(&chunk->bfields[j], 0);                // atomic clear
+        mi_bfield_t b = mi_atomic_exchange_relaxed(&chunk->bfields[j], (mi_bfield_t)0);   // atomic clear
         mi_bfield_t skipped = 0;                                                          // but track which bits we skip so we can restore them
         for(size_t shift = 0; rngslices + shift <= MI_BFIELD_BITS; shift += rngslices) {  // per `rngslices` to keep alignment
           const mi_bfield_t rngmask = mi_bfield_mask(rngslices, shift);

--- a/src/page-map.c
+++ b/src/page-map.c
@@ -308,7 +308,7 @@ void _mi_page_map_unsafe_destroy(mi_subproc_t* subproc) {
   mi_page_map_count = 0;
   mi_page_map_memid = _mi_memid_none();
   mi_page_map_max_address = NULL;
-  mi_atomic_store_release(&mi_page_map_commit, 0);
+  mi_atomic_store_release(&mi_page_map_commit, (mi_bfield_t)0);
 }
 
 


### PR DESCRIPTION
Like #1223 but for dev3. There were more fixes needed than just the one.