### PR TITLE
feat: Support mi_atomic_yield to support ARM Windows and fix order

### DIFF
--- a/include/mimalloc/atomic.h
+++ b/include/mimalloc/atomic.h
@@ -363,14 +363,18 @@ typedef _Atomic(uintptr_t) mi_atomic_guard_t;
 static inline void mi_atomic_yield(void) {
   std::this_thread::yield();
 }
-#elif defined(_WIN32)
-static inline void mi_atomic_yield(void) {
-  YieldProcessor();
-}
 #elif defined(__SSE2__)
 #include <emmintrin.h>
 static inline void mi_atomic_yield(void) {
   _mm_pause();
+}
+#elif defined(_M_ARM) || defined(_M_ARM64)
+static inline void mi_atomic_yield(void) {
+  __yield();
+}
+#elif defined(_WIN32)
+static inline void mi_atomic_yield(void) {
+  YieldProcessor();
 }
 #elif (defined(__GNUC__) || defined(__clang__)) && \
       (defined(__x86_64__) || defined(__i386__) || \


### PR DESCRIPTION
I found a possible issue, while working on https://github.com/python/cpython/issues/144586

* Fixed the order of `__SSE2__` and `_WIN32` checks in `mi_atomic_yield`. Previously, `_WIN32` was checked before `__SSE2__`, which means `_mm_pause()` was likely never activated on Windows builds since `_WIN32` would always match first and fall through to YieldProcessor().
* Added `__yield()` support for ARM Windows builds ([_M_ARM](https://learn.microsoft.com/en-us/cpp/intrinsics/arm-intrinsics?view=msvc-170) / [_M_ARM64](https://learn.microsoft.com/en-us/cpp/intrinsics/arm64-intrinsics?view=msvc-170)) using the MSVC intrinsic.


Please let me know if I missed something.

Warm regards from very cold Seoul,
Donghee