### PR TITLE
Added mi_visit_blocks to visit all blocks of all heaps in a thread

### DIFF
--- a/include/mimalloc.h
+++ b/include/mimalloc.h
@@ -288,7 +288,7 @@ typedef bool (mi_cdecl mi_block_visit_fun)(const mi_heap_t* heap, const mi_heap_
 mi_decl_export bool mi_heap_visit_blocks(const mi_heap_t* heap, bool visit_blocks, mi_block_visit_fun* visitor, void* arg);
 
 //Visiting all blocks of all heaps in a thread
-mi_decl_export bool mi_visit_blocks(bool visit_blocks, mi_block_visit_fun* visitor, void* arg);
+mi_decl_export bool mi_thread_visit_blocks(bool visit_blocks, mi_block_visit_fun* visitor, void* arg);
 
 // Experimental
 mi_decl_nodiscard mi_decl_export bool mi_is_in_heap_region(const void* p) mi_attr_noexcept;

--- a/include/mimalloc.h
+++ b/include/mimalloc.h
@@ -288,7 +288,7 @@ typedef bool (mi_cdecl mi_block_visit_fun)(const mi_heap_t* heap, const mi_heap_
 mi_decl_export bool mi_heap_visit_blocks(const mi_heap_t* heap, bool visit_blocks, mi_block_visit_fun* visitor, void* arg);
 
 //Visiting all blocks of all heaps in a thread
-mi_decl_export bool mi_visit_blocks(const mi_heap_t* heap ,bool visit_blocks, mi_block_visit_fun* visitor, void* arg);
+mi_decl_export bool mi_visit_blocks(bool visit_blocks, mi_block_visit_fun* visitor, void* arg);
 
 // Experimental
 mi_decl_nodiscard mi_decl_export bool mi_is_in_heap_region(const void* p) mi_attr_noexcept;

--- a/include/mimalloc.h
+++ b/include/mimalloc.h
@@ -287,6 +287,9 @@ typedef bool (mi_cdecl mi_block_visit_fun)(const mi_heap_t* heap, const mi_heap_
 
 mi_decl_export bool mi_heap_visit_blocks(const mi_heap_t* heap, bool visit_blocks, mi_block_visit_fun* visitor, void* arg);
 
+//Visiting all blocks of all heaps in a thread
+mi_decl_export bool mi_visit_blocks(const mi_heap_t* heap ,bool visit_blocks, mi_block_visit_fun* visitor, void* arg);
+
 // Experimental
 mi_decl_nodiscard mi_decl_export bool mi_is_in_heap_region(const void* p) mi_attr_noexcept;
 mi_decl_nodiscard mi_decl_export bool mi_is_redirected(void) mi_attr_noexcept;

--- a/src/heap.c
+++ b/src/heap.c
@@ -737,17 +737,18 @@ bool mi_heap_visit_blocks(const mi_heap_t* heap, bool visit_blocks, mi_block_vis
 }
 
 //Visiting all blocks of all heaps in a thread
-bool mi_visit_blocks(bool visit_blocks, mi_block_visit_fun* visitor, void* arg) {
-  mi_assert_internal(heap != NULL);
+bool mi_thread_visit_blocks(bool visit_blocks, mi_block_visit_fun* visitor, void* arg) {
+  mi_heap_t* heap = mi_heap_get_default();
   if (heap == NULL) return false;
+
   mi_heap_t* curr = heap->tld->heaps;
   while (curr != NULL) {
     mi_heap_t* next = curr->next;
-    if(!mi_heap_visit_blocks(curr, visit_blocks, visitor, arg)){
+    if (!mi_heap_visit_blocks(curr, visit_blocks, visitor, arg)) {
       return false;
     }
     curr = next;
   }
+
   return true;
 }
-

--- a/src/heap.c
+++ b/src/heap.c
@@ -737,7 +737,7 @@ bool mi_heap_visit_blocks(const mi_heap_t* heap, bool visit_blocks, mi_block_vis
 }
 
 //Visiting all blocks of all heaps in a thread
-bool mi_visit_blocks(const mi_heap_t* heap, bool visit_blocks, mi_block_visit_fun* visitor, void* arg) {
+bool mi_visit_blocks(bool visit_blocks, mi_block_visit_fun* visitor, void* arg) {
   mi_assert_internal(heap != NULL);
   if (heap == NULL) return false;
   mi_heap_t* curr = heap->tld->heaps;

--- a/src/heap.c
+++ b/src/heap.c
@@ -735,3 +735,19 @@ bool mi_heap_visit_blocks(const mi_heap_t* heap, bool visit_blocks, mi_block_vis
   mi_visit_blocks_args_t args = { visit_blocks, visitor, arg };
   return mi_heap_visit_areas(heap, &mi_heap_area_visitor, &args);
 }
+
+//Visiting all blocks of all heaps in a thread
+bool mi_visit_blocks(const mi_heap_t* heap, bool visit_blocks, mi_block_visit_fun* visitor, void* arg) {
+  mi_assert_internal(heap != NULL);
+  if (heap == NULL) return false;
+  mi_heap_t* curr = heap->tld->heaps;
+  while (curr != NULL) {
+    mi_heap_t* next = curr->next;
+    if(!mi_heap_visit_blocks(curr, visit_blocks, visitor, arg)){
+      return false;
+    }
+    curr = next;
+  }
+  return true;
+}
+


### PR DESCRIPTION

Added a method "mi_visit_blocks()" in src/heap.c to visit all blocks of all heaps in a thread and made required changes in include/mimalloc.h by adding 

`mi_decl_export bool mi_visit_blocks(const mi_heap_t* heap ,bool visit_blocks, mi_block_visit_fun* visitor, void* arg);`

Below is the function I added

```
bool mi_visit_blocks(const mi_heap_t* heap, bool visit_blocks, mi_block_visit_fun* visitor, void* arg) {
  mi_assert_internal(heap != NULL);
  if (heap == NULL) return false;
  mi_heap_t* curr = heap->tld->heaps;
  while (curr != NULL) {
    mi_heap_t* next = curr->next;
    if(!mi_heap_visit_blocks(curr, visit_blocks, visitor, arg)){
      return false;
    }
    curr = next;
  }
  return true;
}

```

This function was tested with the below code

```
#include <stdio.h>
#include <stdlib.h>
#include "mimalloc.h"

static int block_count = 0;


bool visit_block(const mi_heap_t* heap,
                 const mi_heap_area_t* area,
                 void* block,
                 size_t block_size,
                 void* arg)
{
    block_count++;
    printf("Visited block %p size=%zu\n", block, block_size);
    return true;   // continue visiting
}

int main() {

    
    mi_heap_t* heap = mi_heap_new();

    if (heap == NULL) {
        printf("heap creation failed\n");
        return 1;
    }

    
    void* p1 = mi_heap_malloc(heap, 64);
    void* p2 = mi_heap_malloc(heap, 128);
    void* p3 = mi_heap_malloc(heap, 256);

    printf("Allocated blocks: %p %p %p\n", p1, p2, p3);

   
    mi_visit_blocks(heap, true, visit_block, NULL);

    printf("Total blocks visited: %d\n", block_count);

    /* cleanup */
    mi_free(p1);
    mi_free(p2);
    mi_free(p3);

    mi_heap_destroy(heap);

    return 0;
}
```