### PR TITLE
Fix display units of stats counters

### DIFF
--- a/include/mimalloc/internal.h
+++ b/include/mimalloc/internal.h
@@ -418,7 +418,10 @@ typedef struct mi_option_desc_s {
 #define MI_UNUSED_RELEASE(x)  MI_UNUSED(x)
 #endif
 
-#define MI_INIT4(x)   x(),x(),x(),x()
+#define MI_INIT2(x)   x(),x()
+#define MI_INIT3(x)   MI_INIT2(x),x()
+#define MI_INIT4(x)   MI_INIT2(x),MI_INIT2(x)
+#define MI_INIT6(x)   MI_INIT4(x),MI_INIT2(x)
 #define MI_INIT8(x)   MI_INIT4(x),MI_INIT4(x)
 #define MI_INIT16(x)  MI_INIT8(x),MI_INIT8(x)
 #define MI_INIT32(x)  MI_INIT16(x),MI_INIT16(x)

--- a/src/init.c
+++ b/src/init.c
@@ -64,23 +64,22 @@ const mi_page_t _mi_page_empty = {
     QNULL(MI_LARGE_MAX_OBJ_WSIZE + 1  /* 655360, Huge queue */), \
     QNULL(MI_LARGE_MAX_OBJ_WSIZE + 2) /* Full queue */ }
 
-#define MI_STAT_COUNT_NULL()  {0,0,0}
+#define MI_STAT_COUNT_NULL()    {0,0,0}
+#define MI_STAT_COUNTER_NULL()  {0}
 
 // Empty statistics
 #define MI_STATS_NULL  \
-  MI_STAT_COUNT_NULL(), MI_STAT_COUNT_NULL(), MI_STAT_COUNT_NULL(), \
-  { 0 }, { 0 }, \
-  MI_STAT_COUNT_NULL(), MI_STAT_COUNT_NULL(), MI_STAT_COUNT_NULL(), \
-  MI_STAT_COUNT_NULL(), MI_STAT_COUNT_NULL(), MI_STAT_COUNT_NULL(), \
-  { 0 }, { 0 }, { 0 }, { 0 }, \
-  { 0 }, { 0 }, { 0 }, { 0 }, \
+  MI_INIT3(MI_STAT_COUNT_NULL), \
+  MI_INIT2(MI_STAT_COUNTER_NULL), \
+  MI_INIT6(MI_STAT_COUNT_NULL), \
+  MI_INIT8(MI_STAT_COUNTER_NULL), \
   \
-  { 0 }, { 0 }, { 0 }, { 0 }, { 0 }, { 0 }, \
+  MI_INIT6(MI_STAT_COUNTER_NULL), \
   MI_INIT5(MI_STAT_COUNT_NULL), \
-  { 0 }, { 0 }, { 0 }, { 0 },  \
+  MI_INIT4(MI_STAT_COUNTER_NULL), \
   \
   { MI_INIT4(MI_STAT_COUNT_NULL) }, \
-  { { 0 }, { 0 }, { 0 }, { 0 } }, \
+  { MI_INIT4(MI_STAT_COUNTER_NULL) }, \
   \
   { MI_INIT74(MI_STAT_COUNT_NULL) }, \
   { MI_INIT74(MI_STAT_COUNT_NULL) }, \

--- a/src/stats.c
+++ b/src/stats.c
@@ -192,10 +192,10 @@ static void mi_stat_print_ex(const mi_stat_count_t* stat, const char* msg, int64
       mi_print_count(stat->total, unit, out, arg);
     }
     else {
-      mi_print_amount(stat->peak, -1, out, arg);
-      mi_print_amount(stat->total, -1, out, arg);
-      // mi_print_amount(stat->freed, -1, out, arg);
-      mi_print_amount(stat->current, -1, out, arg);
+      mi_print_amount(stat->peak, -unit, out, arg);
+      mi_print_amount(stat->total, -unit, out, arg);
+      // mi_print_amount(stat->freed, -unit, out, arg);
+      mi_print_amount(stat->current, -unit, out, arg);
       if (unit == -1) {
         _mi_fprintf(out, arg, "%24s", "");
       }
@@ -214,10 +214,10 @@ static void mi_stat_print_ex(const mi_stat_count_t* stat, const char* msg, int64
     }
   }
   else {
-    mi_print_amount(stat->peak, 1, out, arg);
-    mi_print_amount(stat->total, 1, out, arg);
+    mi_print_amount(stat->peak, unit, out, arg);
+    mi_print_amount(stat->total, unit, out, arg);
     _mi_fprintf(out, arg, "%11s", " ");  // no freed
-    mi_print_amount(stat->current, 1, out, arg);
+    mi_print_amount(stat->current, unit, out, arg);
     _mi_fprintf(out, arg, "\n");
   }
 }
@@ -235,9 +235,9 @@ static void mi_stat_total_print(const mi_stat_count_t* stat, const char* msg, in
 }
 #endif
 
-static void mi_stat_counter_print(const mi_stat_counter_t* stat, const char* msg, mi_output_fun* out, void* arg ) {
+static void mi_stat_counter_print_ex(const mi_stat_counter_t* stat, const char* msg, const int64_t unit, mi_output_fun* out, void* arg ) {
   _mi_fprintf(out, arg, "  %-10s:", msg);
-  mi_print_amount(stat->total, -1, out, arg);
+  mi_print_amount(stat->total, unit, out, arg);
   _mi_fprintf(out, arg, "\n");
 }
 
@@ -373,12 +373,12 @@ void _mi_stats_print(const char* name, size_t id, mi_stats_t* stats, mi_output_f
     // mi_stat_print(&stats->segments_cache, "-cached", -1, out, arg);
     mi_stat_print(&stats->pages, "pages", -1, out, arg);
     mi_stat_print(&stats->pages_abandoned, "abandoned", -1, out, arg);
-    mi_stat_counter_print(&stats->pages_reclaim_on_alloc, "reclaima", out, arg);
-    mi_stat_counter_print(&stats->pages_reclaim_on_free, "reclaimf", out, arg);
-    mi_stat_counter_print(&stats->pages_reabandon_full, "reabandon", out, arg);
-    mi_stat_counter_print(&stats->pages_unabandon_busy_wait, "waits", out, arg);
-    mi_stat_counter_print(&stats->pages_extended, "extended", out, arg);
-    mi_stat_counter_print(&stats->pages_retire, "retire", out, arg);
+    mi_stat_counter_print_ex(&stats->pages_reclaim_on_alloc, "reclaima", 0, out, arg);
+    mi_stat_counter_print_ex(&stats->pages_reclaim_on_free, "reclaimf", 0,out, arg);
+    mi_stat_counter_print_ex(&stats->pages_reabandon_full, "reabandon", 0, out, arg);
+    mi_stat_counter_print_ex(&stats->pages_unabandon_busy_wait, "waits", 0, out, arg);
+    mi_stat_counter_print_ex(&stats->pages_extended, "extended", 0, out, arg);
+    mi_stat_counter_print_ex(&stats->pages_retire, "retire", 0, out, arg);
     mi_stat_average_print(stats->page_searches_count.total, stats->page_searches.total, "searches", out, arg);
     _mi_fprintf(out, arg, "\n");
   }
@@ -387,25 +387,25 @@ void _mi_stats_print(const char* name, size_t id, mi_stats_t* stats, mi_output_f
     mi_print_header("arenas", out, arg);
     mi_stat_print_ex(&stats->reserved, "reserved", 1, out, arg, "");
     mi_stat_print_ex(&stats->committed, "committed", 1, out, arg, "");
-    mi_stat_counter_print(&stats->reset, "reset", out, arg);
-    mi_stat_counter_print(&stats->purged, "purged", out, arg);
+    mi_stat_counter_print_ex(&stats->reset, "reset", 1, out, arg);
+    mi_stat_counter_print_ex(&stats->purged, "purged", 1, out, arg);
 
-    mi_stat_counter_print(&stats->arena_count, "arenas", out, arg);
-    mi_stat_counter_print(&stats->arena_rollback_count, "rollback", out, arg);
-    mi_stat_counter_print(&stats->mmap_calls, "mmaps", out, arg);
-    mi_stat_counter_print(&stats->commit_calls, "commits", out, arg);
-    mi_stat_counter_print(&stats->reset_calls, "resets", out, arg);
-    mi_stat_counter_print(&stats->purge_calls, "purges", out, arg);
-    mi_stat_counter_print(&stats->malloc_guarded_count, "guarded", out, arg);
-    mi_stat_print_ex(&stats->heaps, "heaps", -1, out, arg, "");
+    mi_stat_counter_print_ex(&stats->arena_count, "arenas", 0, out, arg);
+    mi_stat_counter_print_ex(&stats->arena_rollback_count, "rollback", 0, out, arg);
+    mi_stat_counter_print_ex(&stats->mmap_calls, "mmaps", 0, out, arg);
+    mi_stat_counter_print_ex(&stats->commit_calls, "commits", 0, out, arg);
+    mi_stat_counter_print_ex(&stats->reset_calls, "resets", 0, out, arg);
+    mi_stat_counter_print_ex(&stats->purge_calls, "purges", 0, out, arg);
+    mi_stat_counter_print_ex(&stats->malloc_guarded_count, "guarded", 0, out, arg);
+    mi_stat_print_ex(&stats->heaps, "heaps", 0, out, arg, "");
     _mi_fprintf(out, arg, "\n");
 
     mi_print_header("process", out, arg);
-    mi_stat_print_ex(&stats->threads, "threads", -1, out, arg, "");
+    mi_stat_print_ex(&stats->threads, "threads", 0, out, arg, "");
     _mi_fprintf(out, arg, "  %-10s: %5i\n", "numa nodes", _mi_os_numa_node_count());
     mi_process_info_print_out(out, arg);
+    _mi_fprintf(out, arg, "\n");
   }
-  _mi_fprintf(out, arg, "\n");
 }
 
 


### PR DESCRIPTION
This PR fixes the units that stats are displayed in. Previously all counters were printed in binary mode, which is not always the natural unit (e.g. `commits: 35.4 Ki` vs `commits: 40.5 K`). 

Example: `env MIMALLOC_SHOW_STATS=1 ./build/mimalloc-test-stress`

<details>
<summary>Before</summary>

```
subproc 0
 blocks          peak       total     current       block      total#   
  bin S    1:    21.4 KiB    73.2 MiB     0           8   B       9.6 M    ok
  bin S    4:    86.8 KiB   291.9 MiB     0          32   B       9.5 M    ok
  bin S    6:   133.9 KiB   437.9 MiB     0          48   B       9.5 M    ok
  bin S    9:   211.6 KiB   731.1 MiB     0          80   B       9.5 M    ok
  bin S   13:   409.5 KiB     1.4 GiB   160   B     160   B       9.5 M    not all freed
  bin S   17:    25.7 KiB   456.1 KiB     1.2 KiB   320   B       1.4 K    not all freed
  bin S   18:   384   B     384   B       0         384   B       1        ok
  bin S   21:     0           3.0 GiB     0         640   B       5.0 M    ok
  bin S   23:    28.1 KiB   165.1 MiB     0         896   B     193.3 K    ok
  bin S   25:     1.2 KiB     1.2 KiB     1.2 KiB     1.2 KiB     1        not all freed
  bin S   27:    40.4 KiB   338.3 MiB     0           1.7 KiB   198.0 K    ok
  bin S   31:   319.7 KiB   691.9 MiB     0           3.5 KiB   202.4 K    ok
  bin S   35:   576.2 KiB     1.2 GiB     0           7.0 KiB   191.1 K    ok
  bin M   39:     1.1 MiB     2.6 GiB     0          14.0 KiB   197.1 K    ok
  bin M   41:     3.5 MiB     8.3 MiB     0          20.0 KiB   429        ok
  bin M   43:     0           1.3 GiB     0          28.1 KiB    50.7 K    ok
  bin M   45:     0           7.8 MiB     0          40.1 KiB   200        ok
  bin M   47:     0           2.7 GiB     0          56.2 KiB    52.3 K    ok
  bin M   48:     0          12.5 MiB     0          64.2 KiB   200        ok
  bin M   49:     0          15.6 MiB     0          80.3 KiB   200        ok
  bin L   51:     0          21.8 MiB     0         112.4 KiB   200        ok
  bin L   52:     0          25.0 MiB     0         128.5 KiB   200        ok
  bin L   53:     0          62.5 MiB     0         160.6 KiB   400        ok

  binned    :     6.3 Mi     14.9 Gi      2.6 Ki                           not all freed
  huge      :     0           1.2 Gi      0                                ok
  total     :     6.3 MiB    16.2 GiB     2.6 KiB                          
  malloc req:                12.9 GiB

 pages           peak       total     current       block      total#   
  touched   :    11.6 GiB    11.6 GiB    11.6 GiB                          
  pages     :   550         106.4 Ki      3                                not all freed
  abandoned :   513         278.4 Ki      0                                ok
  reclaima  :    48.0 Ki 
  reclaimf  :   194.4 Ki 
  reabandon :    40.4 Ki 
  waits     :     0      
  extended  :     1.5 Mi 
  retire    :    13.4 Ki 
  searches  :     2.2 avg

 arenas          peak       total     current       block      total#   
  reserved  :   324.4 MiB   324.6 MiB   324.3 MiB                          
  committed :   286.8 MiB     8.4 GiB    37.6 MiB                          
  reset     :     0      
  purged    :     8.4 Gi 
  arenas    :     5      
  rollback  :     0      
  mmaps     :     8      
  commits   :    35.4 Ki 
  resets    :     0      
  purges    :    33.9 Ki 
  guarded   :     0      
  heaps     :     6          51           1                                

 process         peak       total     current       block      total#   
  threads   :    33           1.5 Ki      1                                
  numa nodes:     1
  elapsed   :    28.777 s
  process   : user: 151.844 s, system: 7.745 s, faults: 0, peak rss: 222.8 MiB, peak commit: 286.8 MiB
```

</details>

<details>
<summary>After</summary>

```

subproc 0
 blocks          peak       total     current       block      total#   
  bin S    1:    22.2 KiB    73.2 MiB     0           8   B       9.6 M    ok
  bin S    4:    88.7 KiB   291.9 MiB     0          32   B       9.5 M    ok
  bin S    6:   132.7 KiB   437.9 MiB     0          48   B       9.5 M    ok
  bin S    9:   205.0 KiB   731.1 MiB     0          80   B       9.5 M    ok
  bin S   13:   416.7 KiB     1.4 GiB   160   B     160   B       9.5 M    not all freed
  bin S   17:    25.7 KiB   456.1 KiB     1.2 KiB   320   B       1.4 K    not all freed
  bin S   18:   384   B     384   B       0         384   B       1        ok
  bin S   21:     0           3.0 GiB     0         640   B       5.0 M    ok
  bin S   23:    28.9 KiB   165.1 MiB     0         896   B     193.3 K    ok
  bin S   25:     1.2 KiB     1.2 KiB     1.2 KiB     1.2 KiB     1        not all freed
  bin S   27:    49.1 KiB   338.3 MiB     0           1.7 KiB   198.0 K    ok
  bin S   31:   365.4 KiB   691.9 MiB     0           3.5 KiB   202.4 K    ok
  bin S   35:   484.8 KiB     1.2 GiB     0           7.0 KiB   191.1 K    ok
  bin M   39:     1.1 MiB     2.6 GiB     0          14.0 KiB   197.1 K    ok
  bin M   41:     3.7 MiB     8.5 MiB     0          20.0 KiB   436        ok
  bin M   43:     0           1.3 GiB     0          28.1 KiB    50.7 K    ok
  bin M   45:     0           7.8 MiB     0          40.1 KiB   200        ok
  bin M   47:     0           2.7 GiB     0          56.2 KiB    52.3 K    ok
  bin M   48:     0          12.5 MiB     0          64.2 KiB   200        ok
  bin M   49:     0          15.6 MiB     0          80.3 KiB   200        ok
  bin L   51:     0          21.8 MiB     0         112.4 KiB   200        ok
  bin L   52:     0          25.0 MiB     0         128.5 KiB   200        ok
  bin L   53:     0          62.5 MiB     0         160.6 KiB   400        ok

  binned    :     6.4 MiB    14.9 GiB     2.6 KiB                          not all freed
  huge      :     0           1.2 GiB     0                                ok
  total     :     6.4 MiB    16.2 GiB     2.6 KiB                          
  malloc req:                12.9 GiB

 pages           peak       total     current       block      total#   
  touched   :    11.7 GiB    11.7 GiB    11.7 GiB                          
  pages     :   543   B     107.0 KiB     3   B                            not all freed
  abandoned :   504   B     278.3 KiB     0                                ok
  reclaima  :    48.0 K  
  reclaimf  :   198.2 K  
  reabandon :    40.9 K  
  waits     :     0      
  extended  :     1.6 M  
  retire    :    13.6 K  
  searches  :     2.1 avg

 arenas          peak       total     current       block      total#   
  reserved  :   388.4 MiB   388.7 MiB   388.3 MiB                          
  committed :   288.3 MiB     8.7 GiB    42.3 MiB                          
  reset     :     0      
  purged    :     8.6 GiB
  arenas    :     6      
  rollback  :     0      
  mmaps     :     9      
  commits   :    40.5 K  
  resets    :     0      
  purges    :    38.8 K  
  guarded   :     0      
  heaps     :     6          51                      1      

 process         peak       total     current       block      total#   
  threads   :    33           1.6 K                  1      
  numa nodes:     1
  elapsed   :    29.706 s
  process   : user: 153.935 s, system: 8.472 s, faults: 0, peak rss: 229.1 MiB, peak commit: 288.3 MiB
```

</details>