### PR TITLE
Ensure correct `size_t` mangling on Emscripten

### DIFF
--- a/src/alloc-override.c
+++ b/src/alloc-override.c
@@ -215,26 +215,30 @@ typedef void* mi_nothrow_t;
   void _ZdlPvSt11align_val_tRKSt9nothrow_t(void* p, size_t al, mi_nothrow_t tag) { MI_UNUSED(tag); mi_free_aligned(p,al); } // operator delete(void*, std::align_val_t, std::nothrow_t const&)
   void _ZdaPvSt11align_val_tRKSt9nothrow_t(void* p, size_t al, mi_nothrow_t tag) { MI_UNUSED(tag); mi_free_aligned(p,al); } // operator delete[](void*, std::align_val_t, std::nothrow_t const&)
 
-  #if (MI_INTPTR_SIZE==8)
-    void* _Znwm(size_t n)                             MI_FORWARD1(mi_new,n)  // new 64-bit
-    void* _Znam(size_t n)                             MI_FORWARD1(mi_new,n)  // new[] 64-bit
-    void* _ZnwmRKSt9nothrow_t(size_t n, mi_nothrow_t tag) { MI_UNUSED(tag); return mi_new_nothrow(n); }
-    void* _ZnamRKSt9nothrow_t(size_t n, mi_nothrow_t tag) { MI_UNUSED(tag); return mi_new_nothrow(n); }
-    void* _ZnwmSt11align_val_t(size_t n, size_t al)   MI_FORWARD2(mi_new_aligned, n, al)
-    void* _ZnamSt11align_val_t(size_t n, size_t al)   MI_FORWARD2(mi_new_aligned, n, al)
-    void* _ZnwmSt11align_val_tRKSt9nothrow_t(size_t n, size_t al, mi_nothrow_t tag) { MI_UNUSED(tag); return mi_new_aligned_nothrow(n,al); }
-    void* _ZnamSt11align_val_tRKSt9nothrow_t(size_t n, size_t al, mi_nothrow_t tag) { MI_UNUSED(tag); return mi_new_aligned_nothrow(n,al); }
-  #elif (MI_INTPTR_SIZE==4)
-    void* _Znwj(size_t n)                             MI_FORWARD1(mi_new,n)  // new 64-bit
-    void* _Znaj(size_t n)                             MI_FORWARD1(mi_new,n)  // new[] 64-bit
-    void* _ZnwjRKSt9nothrow_t(size_t n, mi_nothrow_t tag) { MI_UNUSED(tag); return mi_new_nothrow(n); }
-    void* _ZnajRKSt9nothrow_t(size_t n, mi_nothrow_t tag) { MI_UNUSED(tag); return mi_new_nothrow(n); }
-    void* _ZnwjSt11align_val_t(size_t n, size_t al)   MI_FORWARD2(mi_new_aligned, n, al)
-    void* _ZnajSt11align_val_t(size_t n, size_t al)   MI_FORWARD2(mi_new_aligned, n, al)
-    void* _ZnwjSt11align_val_tRKSt9nothrow_t(size_t n, size_t al, mi_nothrow_t tag) { MI_UNUSED(tag); return mi_new_aligned_nothrow(n,al); }
-    void* _ZnajSt11align_val_tRKSt9nothrow_t(size_t n, size_t al, mi_nothrow_t tag) { MI_UNUSED(tag); return mi_new_aligned_nothrow(n,al); }
+  #ifndef MI_SIZE_T_MANGLE
+    #if defined(__EMSCRIPTEN__) || (MI_INTPTR_SIZE==8)
+      #define MI_SIZE_T_MANGLE m
+    #elif (MI_INTPTR_SIZE==4)
+      #define MI_SIZE_T_MANGLE j
+    #endif
+  #endif
+
+  #ifdef MI_SIZE_T_MANGLE
+    #define MI_PASTE2(a, b) MI_PASTE2_IMP(a, b)
+    #define MI_PASTE2_IMP(a, b) a##b
+    #define OP_NEW  MI_PASTE2(_Znw, MI_SIZE_T_MANGLE)  // new
+    #define OP_NEWA MI_PASTE2(_Zna, MI_SIZE_T_MANGLE)  // new[]
+
+    void* OP_NEW(size_t n)  MI_FORWARD1(mi_new, n)
+    void* OP_NEWA(size_t n) MI_FORWARD1(mi_new, n)
+    void* MI_PASTE2(OP_NEW,  RKSt9nothrow_t)(size_t n, mi_nothrow_t tag) { MI_UNUSED(tag); return mi_new_nothrow(n); }
+    void* MI_PASTE2(OP_NEWA, RKSt9nothrow_t)(size_t n, mi_nothrow_t tag) { MI_UNUSED(tag); return mi_new_nothrow(n); }
+    void* MI_PASTE2(OP_NEW,  St11align_val_t)(size_t n, size_t al) MI_FORWARD2(mi_new_aligned, n, al)
+    void* MI_PASTE2(OP_NEWA, St11align_val_t)(size_t n, size_t al) MI_FORWARD2(mi_new_aligned, n, al)
+    void* MI_PASTE2(OP_NEW,  St11align_val_tRKSt9nothrow_t)(size_t n, size_t al, mi_nothrow_t tag) { MI_UNUSED(tag); return mi_new_aligned_nothrow(n, al); }
+    void* MI_PASTE2(OP_NEWA, St11align_val_tRKSt9nothrow_t)(size_t n, size_t al, mi_nothrow_t tag) { MI_UNUSED(tag); return mi_new_aligned_nothrow(n, al); }
   #else
-    #error "define overloads for new/delete for this platform (just for performance, can be skipped)"
+    #error "could not determine MI_SIZE_T_MANGLE for this platform"
   #endif
 #endif // __cplusplus
 


### PR DESCRIPTION
Emscripten defines `size_t` as `unsigned long` for both wasm32 and wasm64, mangling must therefore use `m` (Itanium ABI), independent of the pointer size.

<details>
  <summary>Details</summary>

```console
$ llvm-nm -pU --quiet $EMSDK/upstream/emscripten/cache/sysroot/lib/wasm32-emscripten/libc++.a | grep -e _Zn
00000001 W _Znwm
0000004a W _ZnwmRKSt9nothrow_t
00000110 W _Znam
0000011b W _ZnamRKSt9nothrow_t
00000210 W _ZnwmSt11align_val_t
0000028c W _ZnwmSt11align_val_tRKSt9nothrow_t
0000033f W _ZnamSt11align_val_t
0000034c W _ZnamSt11align_val_tRKSt9nothrow_t
$ llvm-nm -pU --quiet $EMSDK/upstream/emscripten/cache/sysroot/lib/wasm64-emscripten/libc++.a | grep -e _Zn
00000001 W _Znwm
0000004d W _ZnwmRKSt9nothrow_t
0000013b W _Znam
00000146 W _ZnamRKSt9nothrow_t
00000263 W _ZnwmSt11align_val_t
000002e2 W _ZnwmSt11align_val_tRKSt9nothrow_t
000003bd W _ZnamSt11align_val_t
000003ca W _ZnamSt11align_val_tRKSt9nothrow_t
$ emcc -dM -E - < /dev/null | grep -e __SIZEOF_SIZE_T__ -e __SIZE_TYPE__
#define __SIZEOF_SIZE_T__ 4
#define __SIZE_TYPE__ long unsigned int
$ emcc -sMEMORY64 -dM -E - < /dev/null | grep -e __SIZEOF_SIZE_T__ -e __SIZE_TYPE__
#define __SIZEOF_SIZE_T__ 8
#define __SIZE_TYPE__ long unsigned int
```
</details>

See also: https://github.com/emscripten-core/emscripten/pull/5916.