### PR TITLE
Fix TLS index and virtual reservation leaks on DLL unload

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -546,6 +546,7 @@ static void mi_subprocs_unsafe_destroy_all(void) {
     }
   }
   mi_subproc_unsafe_destroy(&subproc_main);
+  _mi_arenas_unsafe_destroy_all(&subproc_main);  // free main subproc arenas (needed for DLL unload)
 }
 
 
@@ -772,8 +773,13 @@ mi_decl_hidden size_t _mi_theap_default_expansion_slot = MI_TLS_INITIAL_EXPANSIO
 mi_decl_hidden size_t _mi_theap_cached_slot            = MI_TLS_INITIAL_SLOT;
 mi_decl_hidden size_t _mi_theap_cached_expansion_slot  = MI_TLS_INITIAL_EXPANSION_SLOT;
 
-static size_t mi_win_tls_slot_alloc(size_t* extended) {
+// Raw TLS indices for cleanup via TlsFree (avoids reverse-engineering the stored slot)
+static DWORD mi_tls_raw_default = TLS_OUT_OF_INDEXES;
+static DWORD mi_tls_raw_cached  = TLS_OUT_OF_INDEXES;
+
+static size_t mi_win_tls_slot_alloc(size_t* extended, DWORD* raw_tls_index) {
   const DWORD slot = TlsAlloc();
+  if (raw_tls_index != NULL) { *raw_tls_index = slot; }
   if (slot==TLS_OUT_OF_INDEXES || slot >= MI_TLS_DIRECT_SLOTS + MI_TLS_EXPANSION_SLOTS - 1) {
     // note: we also fail if the program already allocated the maximum number of expansion slots (as we use the last one as the default)
     *extended = 0;
@@ -797,13 +803,26 @@ static size_t mi_win_tls_slot_alloc(size_t* extended) {
 mi_decl_cold mi_theap_t* _mi_win_tls_slots_init(void) {
   static mi_atomic_once_t tls_slots_init;
   if (mi_atomic_once(&tls_slots_init)) {
-    _mi_theap_default_slot = mi_win_tls_slot_alloc(&_mi_theap_default_expansion_slot);
-    _mi_theap_cached_slot = mi_win_tls_slot_alloc(&_mi_theap_cached_expansion_slot);
+    _mi_theap_default_slot = mi_win_tls_slot_alloc(&_mi_theap_default_expansion_slot, &mi_tls_raw_default);
+    _mi_theap_cached_slot = mi_win_tls_slot_alloc(&_mi_theap_cached_expansion_slot, &mi_tls_raw_cached);
     if (_mi_theap_cached_slot==0) {
       _mi_error_message(EFAULT, "unable to allocate fast TLS user slot (0x%zx)\n", _mi_theap_cached_slot);
     }
   }
   return (mi_theap_t*)&_mi_theap_empty;
+}
+
+static void mi_win_tls_slots_done(void) {
+  if (mi_tls_raw_default != TLS_OUT_OF_INDEXES) {
+    TlsFree(mi_tls_raw_default);
+    mi_tls_raw_default = TLS_OUT_OF_INDEXES;
+  }
+  if (mi_tls_raw_cached != TLS_OUT_OF_INDEXES) {
+    TlsFree(mi_tls_raw_cached);
+    mi_tls_raw_cached = TLS_OUT_OF_INDEXES;
+  }
+  _mi_theap_default_slot = MI_TLS_INITIAL_SLOT;
+  _mi_theap_cached_slot = MI_TLS_INITIAL_SLOT;
 }
 
 static void mi_win_tls_slot_set(size_t slot, size_t extended_slot, void* value) {
@@ -1092,6 +1111,9 @@ void mi_cdecl mi_process_done(void) mi_attr_noexcept {
     mi_subproc_stats_print_out(NULL, NULL, NULL);
   }
   mi_lock_done(&subprocs_lock);
+  #if MI_TLS_MODEL_DYNAMIC_WIN32
+  mi_win_tls_slots_done();
+  #endif
   _mi_allocator_done();
   _mi_verbose_message("process done: 0x%zx\n", tld_main.thread_id);
   os_preloading = true; // don't call the C runtime anymore

--- a/src/init.c
+++ b/src/init.c
@@ -1014,7 +1014,8 @@ void mi_process_init(void) mi_attr_noexcept {
 	// #endif
   if (!mi_atomic_once(&process_init)) return;
   _mi_verbose_message("process init: 0x%zx\n", _mi_thread_id());
-
+    // Release reserved page-map and arena allocations at process shutdown for verifier runs.
+  mi_option_enable(mi_option_destroy_on_exit);
   mi_detect_cpu_features();
   _mi_options_init();
   _mi_stats_init();


### PR DESCRIPTION
Summary
When mimalloc is statically linked into a DLL that is repeatedly loaded/unloaded, Application Verifier reports two resource leaks on DLL_PROCESS_DETACH. This PR fixes both.

Changes
1. Fix VERIFIER STOP 0x350 — TLS index not freed

mi_win_tls_slot_alloc() calls TlsAlloc() twice (for _mi_theap_default_slot and _mi_theap_cached_slot) but TlsFree() is never called on DLL unload.

Fix: Save the raw DWORD returned by TlsAlloc() into mi_tls_raw_default / mi_tls_raw_cached, and free them via mi_win_tls_slots_done() called from mi_process_done(). This avoids trying to reverse-engineer the original TLS index from mimalloc's internal slot representation, which is fragile and error-prone (e.g. expansion slots would compute wrong indices).

2. Fix VERIFIER STOP 0x903 — Virtual reservation leaked

mi_subproc_unsafe_destroy() only calls _mi_arenas_unsafe_destroy_all() for non-main subprocesses (guarded by if (subproc != &subproc_main)). When mi_subprocs_unsafe_destroy_all() destroys the main subproc, its arena virtual memory reservations (VirtualAlloc(MEM_RESERVE)) are never released via VirtualFree.

Fix: Add _mi_arenas_unsafe_destroy_all(&subproc_main) after mi_subproc_unsafe_destroy(&subproc_main) in mi_subprocs_unsafe_destroy_all().

3. Enable destroy_on_exit by default

Set mi_option_enable(mi_option_destroy_on_exit) in mi_process_init() so arena and page-map cleanup runs automatically on process/DLL shutdown, which is required for the DLL unload scenario.

Testing
Verified with Windows Application Verifier (leak checks enabled) on a DLL that statically links mimalloc. Both 0x350 and 0x903 verifier stops are resolved after these changes.