### PR TITLE
Add opt-in Windows fallback mode for _pRawDllMain conflicts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ option(MI_OSX_INTERPOSE     "Use interpose to override standard malloc on macOS"
 option(MI_OSX_ZONE          "Use malloc zone to override standard malloc on macOS" ON)
 option(MI_WIN_REDIRECT      "Use redirection module ('mimalloc-redirect') on Windows if compiling mimalloc as a DLL" ON)
 option(MI_WIN_DIRECT_TLS    "Use only direct TLS slots on Windows to avoid extra tests in the malloc fast path (only works if the program uses less than 64 TlsAlloc'd slots in total)" OFF)
+option(MI_WIN_CRT_XIU_FALLBACK "Use .CRT$XIU/atexit for process attach/detach and TLS callbacks only for thread detach on Windows static builds when _pRawDllMain conflicts" OFF)
 option(MI_LOCAL_DYNAMIC_TLS "Use local-dynamic-tls, a slightly slower but dlopen-compatible thread local storage mechanism (Unix)" OFF)
 option(MI_LIBC_MUSL         "Enable this when linking with musl libc" OFF)
 
@@ -413,6 +414,11 @@ endif()
 if(MI_WIN_USE_FLS)
   message(STATUS "Use the Fiber API to detect thread termination (deprecated) (MI_WIN_USE_FLS=ON)")
   list(APPEND mi_defines MI_WIN_USE_FLS=1)
+endif()
+
+if(MI_WIN_CRT_XIU_FALLBACK)
+  message(STATUS "Use .CRT$XIU/atexit process lifecycle and TLS callbacks only for thread detach on Windows static builds (MI_WIN_CRT_XIU_FALLBACK=ON)")
+  list(APPEND mi_defines MI_WIN_CRT_XIU_FALLBACK=1)
 endif()
 
 if(MI_WIN_DIRECT_TLS)

--- a/src/prim/windows/prim.c
+++ b/src/prim/windows/prim.c
@@ -723,7 +723,7 @@ static void NTAPI mi_win_main(PVOID module, DWORD reason, LPVOID reserved) {
    By default we use a combination of _pRawDllMain and TLS sections for
    both static and dynamic linkage
 ------------------------------------------------------------------------- */
-#ifndef MI_WIN_NO_RAW_DLLMAIN
+#if !defined(MI_WIN_NO_RAW_DLLMAIN) && !defined(MI_WIN_CRT_XIU_FALLBACK)
   #define MI_PRIM_HAS_PROCESS_ATTACH  1
   // nothing to do since `_mi_thread_done` is handled through the DLL_THREAD_DETACH event.
   void _mi_prim_thread_init_auto_done(void) {}
@@ -824,6 +824,82 @@ static void NTAPI mi_win_main(PVOID module, DWORD reason, LPVOID reserved) {
     mi_win_main((PVOID)inst,reason,reserved);
     return TRUE;
   }
+
+  // nothing to do since `_mi_thread_done` is handled through the DLL_THREAD_DETACH event.
+  void _mi_prim_thread_init_auto_done(void) { }
+  void _mi_prim_thread_done_auto_done(void) { }
+  void _mi_prim_thread_associate_default_theap(mi_theap_t* theap) {
+    MI_UNUSED(theap);
+  }
+
+#elif defined(MI_WIN_CRT_XIU_FALLBACK)
+  #define MI_PRIM_HAS_PROCESS_ATTACH  1
+
+  // TLS callbacks for per-thread attach/detach only.
+  // Process-level init and cleanup are handled separately via .CRT$XIU + atexit
+  // so mi_process_done runs after DllMain(DLL_PROCESS_DETACH) during FreeLibrary.
+  static void NTAPI mi_win_main_attach(PVOID module, DWORD reason, LPVOID reserved) {
+    if (reason == DLL_THREAD_ATTACH) {
+      mi_win_main(module, reason, reserved);
+    }
+  }
+  static void NTAPI mi_win_main_detach(PVOID module, DWORD reason, LPVOID reserved) {
+    if (reason == DLL_THREAD_DETACH) {
+      mi_win_main(module, reason, reserved);
+    }
+  }
+
+  // Set up TLS callbacks in a statically linked library by using special data sections.
+  // These callbacks only handle per-thread notifications in this fallback mode.
+  #if defined(__cplusplus)
+  extern "C" {
+  #endif
+
+  #if defined(_WIN64)
+    #pragma comment(linker, "/INCLUDE:_tls_used")
+    #pragma comment(linker, "/INCLUDE:_mi_tls_callback_pre")
+    #pragma comment(linker, "/INCLUDE:_mi_tls_callback_post")
+    #pragma const_seg(".CRT$XLB")
+    extern const PIMAGE_TLS_CALLBACK _mi_tls_callback_pre[];
+    const PIMAGE_TLS_CALLBACK _mi_tls_callback_pre[] = { &mi_win_main_attach };
+    #pragma const_seg()
+    #pragma const_seg(".CRT$XLY")
+    extern const PIMAGE_TLS_CALLBACK _mi_tls_callback_post[];
+    const PIMAGE_TLS_CALLBACK _mi_tls_callback_post[] = { &mi_win_main_detach };
+    #pragma const_seg()
+  #else
+    #pragma comment(linker, "/INCLUDE:__tls_used")
+    #pragma comment(linker, "/INCLUDE:__mi_tls_callback_pre")
+    #pragma comment(linker, "/INCLUDE:__mi_tls_callback_post")
+    #pragma data_seg(".CRT$XLB")
+    PIMAGE_TLS_CALLBACK _mi_tls_callback_pre[] = { &mi_win_main_attach };
+    #pragma data_seg()
+    #pragma data_seg(".CRT$XLY")
+    PIMAGE_TLS_CALLBACK _mi_tls_callback_post[] = { &mi_win_main_detach };
+    #pragma data_seg()
+  #endif
+
+  #if defined(__cplusplus)
+  }
+  #endif
+
+  #if defined(_MSC_VER)
+    static int mi_process_attach_crt(void) {
+      mi_win_main(NULL, DLL_PROCESS_ATTACH, NULL);
+      atexit(&_mi_auto_process_done);
+      return 0;
+    }
+    typedef int(*mi_crt_callback_t)(void);
+    #if defined(_WIN64)
+      #pragma comment(linker, "/INCLUDE:_mi_crt_init")
+      #pragma section(".CRT$XIU", long, read)
+    #else
+      #pragma comment(linker, "/INCLUDE:__mi_crt_init")
+    #endif
+    #pragma data_seg(".CRT$XIU")
+    mi_decl_externc mi_crt_callback_t _mi_crt_init[] = { &mi_process_attach_crt };
+    #pragma data_seg()
+  #endif
 
   // nothing to do since `_mi_thread_done` is handled through the DLL_THREAD_DETACH event.
   void _mi_prim_thread_init_auto_done(void) { }


### PR DESCRIPTION
This PR adds MI_WIN_CRT_XIU_FALLBACK, an opt-in Windows fallback mode for
statically linked mimalloc builds.

When enabled, mimalloc:

- does not define _pRawDllMain
- handles process attach through .CRT$XIU
- handles process teardown through atexit
- keeps thread notifications on TLS callbacks

This is intended for integrations where another static library already
defines _pRawDllMain and causes a LNK2005 conflict at final DLL link time.

The default Windows behavior is unchanged. This is a compatibility fallback,
not a replacement for the current _pRawDllMain-based path.