### PR TITLE
fix a cast of argument to `GetModuleHandleExA()`

### DIFF
--- a/src/prim/windows/prim.c
+++ b/src/prim/windows/prim.c
@@ -761,7 +761,7 @@ static void NTAPI mi_win_main(PVOID module, DWORD reason, LPVOID reserved) {
 
   static bool mi_current_module_is_dll(void) {
     HMODULE mod = NULL;
-    const BOOL ok = GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, (LPCTSTR)mi_current_module_is_dll, &mod);
+    const BOOL ok = GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, (LPCSTR)mi_current_module_is_dll, &mod);
     return (ok && mi_module_is_dll(mod));
   }
 


### PR DESCRIPTION
`GetModuleHandleExA()` always expects `LPCSTR` (`const char*`), while `LPCTSTR` can be `const wchar_t*` on Unicode builds, causing a compilation error.
Simply change the cast since the argument itself is not a string anyway.

---

Alternatively, `GetModuleHandleExA()` could be changed to the `GetModuleHandleEx()` macro which accepts `LPCTSTR`, but I don't think this is what was meant here.