### PR TITLE
Emscripten: add missing include for `getentropy()`

### DIFF
--- a/src/prim/emscripten/prim.c
+++ b/src/prim/emscripten/prim.c
@@ -12,6 +12,8 @@ terms of the MIT license. A copy of the license can be found in the file
 #include "mimalloc/atomic.h"
 #include "mimalloc/prim.h"
 
+#include <unistd.h>  // getentropy
+
 // Design
 // ======
 //


### PR DESCRIPTION
This header was previously transitively included to support `sleep()` in `mimalloc/atomic.h`, which is no longer present in `dev3` (see commit 911443d0838bc2874e7dd001006c410c407fd66f).
<details>
  <summary>Details</summary>

```console
In file included from src/prim/prim.c:22:
src/prim/emscripten/prim.c:199:13: error: call to undeclared function 'getentropy'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  195 |   int err = getentropy(buf, buf_len);
      |             ^
1 error generated.
```
</details>

As noticed in PR https://github.com/emscripten-core/emscripten/pull/26696.