### PR TITLE
bugfix: add theap->tld null check

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -424,7 +424,7 @@ mi_subproc_t* _mi_subproc(void) {
   //       on such systems we can check for this with the _mi_prim_get_default_theap as those are protected (by being
   //       stored in a TLS slot for example)
   mi_theap_t* theap = _mi_theap_default();
-  if (theap == NULL) {
+  if (theap == NULL || theap->tld == NULL) {
     return _mi_subproc_main();
   }
   else {


### PR DESCRIPTION
related to [issues 1288](https://github.com/microsoft/mimalloc/issues/1288)
### possible trigger condition: 
after _mi_thread_done (the pthread destructor) completes execution on a thread, the same thread continues to execute other destructors or callbacks. this triggers a mi_free on an abandoned page, which then enters mimalloc re-entrantly via __emutls_get_address → malloc. at this point, the theap returned by _mi_theap_default() is already in a corrupted/invalid state.

### changes: 
added a temporary null check for theap->tld. under this edge case, the allocator can safely fall back to subproc_main.