### PR TITLE
RISC-V: detect virtual address space at runtime using hwprobe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -422,16 +422,6 @@ else()
   # list(APPEND mi_defines MI_WIN_INIT_USE_CRT_TLS=1)
 endif()
 
-# Check /proc/cpuinfo for an SV39 MMU and limit the virtual address bits.
-# (this will skip the aligned hinting in that case. Issue #939, #949)
-if (EXISTS /proc/cpuinfo)
-  file(STRINGS /proc/cpuinfo mi_sv39_mmu REGEX "^mmu[ \t]+:[ \t]+sv39$")
-  if (mi_sv39_mmu)
-    MESSAGE( STATUS "Set virtual address bits to 39 (SV39 MMU detected)" )
-    list(APPEND mi_defines MI_DEFAULT_VIRTUAL_ADDRESS_BITS=39)
-  endif()
-endif()
-
 # On Haiku use `-DCMAKE_INSTALL_PREFIX` instead, issue #788
 # if(CMAKE_SYSTEM_NAME MATCHES "Haiku")
 #   SET(CMAKE_INSTALL_LIBDIR ~/config/non-packaged/lib)

--- a/src/prim/unix/prim.c
+++ b/src/prim/unix/prim.c
@@ -41,6 +41,13 @@ terms of the MIT license. A copy of the license can be found in the file
   #else
   #include <sys/mman.h>
   #endif
+  #if defined(__riscv) || defined(_M_RISCV)
+    #if __has_include(<sys/hwprobe.h>)
+      #include <sys/hwprobe.h>
+    #elif __has_include(<asm/hwprobe.h>)
+      #include <asm/hwprobe.h>
+    #endif
+  #endif
 #elif defined(__APPLE__)
   #include <AvailabilityMacros.h>
   #include <TargetConditionals.h>
@@ -187,6 +194,52 @@ static void unix_detect_physical_memory( size_t page_size, size_t* physical_memo
   #endif
 }
 
+// Detect the virtual address bits (currently Linux/RISC-V only)
+static size_t unix_detect_virtual_address_bits(void)
+{
+  #if defined(__riscv) || defined(_M_RISCV)
+    #ifdef RISCV_HWPROBE_KEY_HIGHEST_VIRT_ADDRESS
+      struct riscv_hwprobe probe = {
+          .key = RISCV_HWPROBE_KEY_HIGHEST_VIRT_ADDRESS,
+      };
+
+      // Prefer the GNU libc interface if available, as it can also use the VDSO
+      #if __has_include(<sys/hwprobe.h>)
+      if (__riscv_hwprobe(&probe, 1, 0, NULL, 0) == 0) {
+      #else
+      if (syscall(__NR_riscv_hwprobe, &probe, 1, 0, NULL, 0) == 0) {
+      #endif
+        // If a key is unknown to the kernel, its key field will be cleared to -1.
+        if (probe.key != -1) {
+          return MI_SIZE_BITS - mi_clz((uintptr_t)probe.value);
+        }
+      }
+    #endif
+
+    // Fallback to checking /proc/cpuinfo for older kernels
+    int fd = mi_prim_open("/proc/cpuinfo", O_RDONLY);
+    if (fd >= 0) {
+      char buf[4096];
+      ssize_t nread = mi_prim_read(fd, &buf, sizeof(buf));
+      mi_prim_close(fd);
+      if (nread >= 1) {
+        if (_mi_strnstr(buf, nread, "sv39")) {
+          return 39;
+        }
+        if (_mi_strnstr(buf, nread, "sv48")) {
+          return 48;
+        }
+        if (_mi_strnstr(buf, nread, "sv57")) {
+          return 57;
+        }
+      }
+    }
+  #endif
+
+  // default: MI_MAX_VABITS
+  return MI_MAX_VABITS;
+}
+
 void _mi_prim_mem_init( mi_os_mem_config_t* config )
 {
   long psize = sysconf(_SC_PAGESIZE);
@@ -199,6 +252,7 @@ void _mi_prim_mem_init( mi_os_mem_config_t* config )
   config->has_overcommit = unix_detect_overcommit();
   config->has_partial_free = true;    // mmap can free in parts
   config->has_virtual_reserve = true; // todo: check if this true for NetBSD?  (for anonymous mmap with PROT_NONE)
+  config->virtual_address_bits = unix_detect_virtual_address_bits();
 
   // disable transparent huge pages for this process?
   #if (defined(__linux__) || defined(__ANDROID__)) && defined(PR_GET_THP_DISABLE)


### PR DESCRIPTION
The virtual address space on RISC-V is currently detected at build time by parsing /proc/cpuinfo. This works when the binary runs on the same hardware it was built, however running such a binary on a system with a larger address space just causes a segmentation fault.

Replace the build time check with a runtime detection using the hwprobe interface (available since Linux 6.11, commit c9b8cd139c1d "riscv: hwprobe export highest virtual userspace address"). For older kernels, fallback to the default 48 bits. This is suboptimal on SV39 MMUs but still works.