### PR TITLE
Prevent reading uninitialized memory in unix_detect_thp()

### DIFF
--- a/src/prim/unix/prim.c
+++ b/src/prim/unix/prim.c
@@ -156,7 +156,7 @@ static bool unix_detect_thp(void) {
     // <https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html>
     // between brackets is the current value, for example: always [madvise] never
     if (nread >= 1) {
-      thp_enabled = (_mi_strnstr(buf,32,"[never]") == NULL);
+      thp_enabled = (_mi_strnstr(buf,nread,"[never]") == NULL);
     }
   }
   #endif


### PR DESCRIPTION
`buf[32]` contains uninitialized memory; once reading the file content we search for a particular string which, if not found in the file read, leads to comparing uninitialized bytes at the end of `buf` to the string we are looking for, leading to undefined behavior (altough it would be highly unlikely that the uninitialized bytes would contain the string we are looking for).