### PR TITLE
aarch64: add SVE-accelerated memcpy and memzero

### DIFF
--- a/include/mimalloc/internal.h
+++ b/include/mimalloc/internal.h
@@ -1100,10 +1100,25 @@ static inline size_t mi_popcount(size_t x) {
 // (AMD Zen3+ (~2020) or Intel Ice Lake+ (~2017). See also issue #201 and pr #253.
 // ---------------------------------------------------------------------------------
 
+// Check for AArch64 SVE compiler capability
+#if defined(__aarch64__) && \
+    ((defined(__GNUC__) && __GNUC__ >= 10) || \
+     (defined(__clang__) && __clang_major__ >= 11))
+  #define MI_HAS_SVE_SUPPORT
+#endif
+
+// Platform-specific memory primitive overrides (e.g. SVE on AArch64)
+#if defined(MI_HAS_SVE_SUPPORT)
+extern mi_decl_hidden void _mi_prim_memcpy(void* dst, const void* src, size_t n);
+extern mi_decl_hidden void _mi_prim_memzero(void* dst, size_t n);
+#endif
+
 #if !MI_TRACK_ENABLED && defined(_WIN32) && (defined(_M_IX86) || defined(_M_X64))
 #include <intrin.h>
 extern mi_decl_hidden bool _mi_cpu_has_fsrm;
 extern mi_decl_hidden bool _mi_cpu_has_erms;
+
+// Optimization for x86/x64 using Fast Short REP MOVSB (FSRM)
 static inline void _mi_memcpy(void* dst, const void* src, size_t n) {
   if (_mi_cpu_has_fsrm && n <= 127) { // || (_mi_cpu_has_erms && n > 128)) {
     __movsb((unsigned char*)dst, (const unsigned char*)src, n);
@@ -1120,7 +1135,16 @@ static inline void _mi_memzero(void* dst, size_t n) {
     memset(dst, 0, n);
   }
 }
+#elif defined(MI_HAS_SVE_SUPPORT) // Use our new compiler-safe gate
+  // Bridge to AArch64 optimized primitives (SVE accelerated)
+  static inline void _mi_memcpy(void* dst, const void* src, size_t n) {
+    _mi_prim_memcpy(dst, src, n);
+  }
+  static inline void _mi_memzero(void* dst, size_t n) {
+    _mi_prim_memzero(dst, n);
+  }
 #else
+// Default fallback to standard library
 static inline void _mi_memcpy(void* dst, const void* src, size_t n) {
   memcpy(dst, src, n);
 }

--- a/src/prim/unix/prim.c
+++ b/src/prim/unix/prim.c
@@ -911,6 +911,149 @@ bool _mi_prim_random_buf(void* buf, size_t buf_len) {
 
 #endif
 
+#include <string.h> // For memset and memcpy fallbacks
+#include <stdint.h> // For uint8_t, uint64_t types
+
+// 1. Detect compiler support for SVE ACLE
+#if defined(__aarch64__) && \
+    ((defined(__GNUC__) && __GNUC__ >= 10) || \
+     (defined(__clang__) && __clang_major__ >= 11))
+  #define MI_HAS_SVE_SUPPORT
+  #include <arm_sve.h> // Only include SVE headers if the compiler supports them
+  #include <sys/auxv.h>
+  #include <asm/hwcap.h>
+#endif
+
+#if defined(MI_HAS_SVE_SUPPORT)
+// Runtime check for SVE capability and it's vector length.
+// Executes getauxval only once per process lifetime.
+#if defined(__clang__)
+  __attribute__((target("sve")))
+#else
+  __attribute__((target("+sve")))
+#endif
+static inline bool _mi_prim_has_sve(void) {
+  static int has_sve_optimized = -1; // -1: Uninitialized
+  if (has_sve_optimized < 0) {
+    unsigned long hwcap = getauxval(AT_HWCAP);
+    if (hwcap & HWCAP_SVE) {
+      // Hardware supports SVE. Now check if VL is at least 256-bit (32 bytes)
+      // to ensure we outperform optimized 128-bit Neon/Scalar paths.
+      if (svcntb() >= 32) {
+        has_sve_optimized = 1;
+      } else {
+        has_sve_optimized = 0; // SVE exists but is only 128-bit (e.g., Graviton 4)
+      }
+    } else {
+      has_sve_optimized = 0; // No SVE support
+    }
+  }
+  return (has_sve_optimized > 0);
+}
+
+// SVE-accelerated memory zeroing.
+// Uses target attributes to allow compilation with base ARMv8-A architecture
+// while generating SVE instructions for the optimized path.
+#if defined(__clang__)
+  __attribute__((target("sve")))
+#else
+  __attribute__((target("+sve")))
+#endif
+static void _mi_prim_sve_memzero(void* p, size_t n) {
+  uint8_t* ptr = (uint8_t*)p;
+  uint64_t remaining = (uint64_t)n;
+  const uint64_t vl = svcntb(); // Vector length in bytes
+  const uint64_t vl4 = vl * 4;
+
+  // Bulk Path: 4x unrolled to maximize pipeline throughput
+  while (remaining >= vl4) {
+    svbool_t pg = svptrue_b8();
+    svst1_u8(pg, ptr,          svdup_u8(0));
+    svst1_u8(pg, ptr + vl,     svdup_u8(0));
+    svst1_u8(pg, ptr + vl * 2, svdup_u8(0));
+    svst1_u8(pg, ptr + vl * 3, svdup_u8(0));
+    ptr += vl4;
+    remaining -= vl4;
+  }
+
+  // Tail Path: Predicated stores handle remaining bytes (Vector Length Agnostic)
+  uint64_t offset = 0;
+  while (offset < remaining) {
+    svbool_t pg = svwhilelt_b8_u64(offset, remaining);
+    svst1_u8(pg, ptr + offset, svdup_u8(0));
+    offset += vl;
+  }
+}
+
+// SVE-accelerated memory copy
+#if defined(__clang__)
+  __attribute__((target("sve")))
+#else
+  __attribute__((target("+sve")))
+#endif
+static void _mi_prim_sve_memcpy(void* restrict dest, const void* restrict src, size_t n) {
+  uint8_t* d = (uint8_t*)dest;
+  const uint8_t* s = (const uint8_t*)src;
+  uint64_t remaining = (uint64_t)n;
+  const uint64_t vl = svcntb();
+  const uint64_t vl4 = vl * 4;
+
+  // Bulk Path: 4x unrolled to saturate memory bandwidth
+  while (remaining >= vl4) {
+    svbool_t pg = svptrue_b8();
+    svuint8_t r0 = svld1_u8(pg, s);
+    svuint8_t r1 = svld1_u8(pg, s + vl);
+    svuint8_t r2 = svld1_u8(pg, s + vl * 2);
+    svuint8_t r3 = svld1_u8(pg, s + vl * 3);
+
+    svst1_u8(pg, d, r0);
+    svst1_u8(pg, d + vl, r1);
+    svst1_u8(pg, d + vl * 2, r2);
+    svst1_u8(pg, d + vl * 3, r3);
+
+    d += vl4;
+    s += vl4;
+    remaining -= vl4;
+  }
+
+  // Tail Path: Predicated loads/stores for the remainder
+  uint64_t offset = 0;
+  while (offset < remaining) {
+    svbool_t pg = svwhilelt_b8_u64(offset, remaining);
+    svuint8_t r = svld1_u8(pg, s + offset);
+    svst1_u8(pg, d + offset, r);
+    offset += vl;
+  }
+}
+#endif // MI_HAS_SVE_SUPPORT
+
+// --- Public Primitive API ---
+
+void _mi_prim_memzero(void* p, size_t n) {
+  if (p == NULL || n == 0) return;
+#if defined(MI_HAS_SVE_SUPPORT)
+  // Use SVE for n >= 2KB if VL >= 256-bit. Smaller sizes or 128-bit VL systems (e.g., Graviton 4)
+  // utilize standard paths to avoid setup overhead and maximize instruction efficiency.
+  if (n >= 2048 && _mi_prim_has_sve()) {
+    _mi_prim_sve_memzero(p, n);
+    return;
+  }
+#endif
+  memset(p, 0, n);
+}
+
+void _mi_prim_memcpy(void* dest, const void* src, size_t n) {
+  if (dest == NULL || src == NULL || n == 0) return;
+#if defined(MI_HAS_SVE_SUPPORT)
+  // Use SVE for n >= 2KB if VL >= 256-bit. Smaller sizes or 128-bit VL systems (e.g., Graviton 4)
+  // utilize standard paths to avoid setup overhead and maximize instruction efficiency.
+  if (n >= 2048 && _mi_prim_has_sve()) {
+    _mi_prim_sve_memcpy(dest, src, n);
+    return;
+  }
+#endif
+  memcpy(dest, src, n);
+}
 
 //----------------------------------------------------------------
 // Thread init/done


### PR DESCRIPTION
## **Summary**
This PR introduces high-performance **Vector Length Agnostic (VLA)** primitives for **memzero** and **memcpy** on AArch64 using **Scalable Vector Extensions (SVE)**.

**Key Technical Features:**
***VLA Implementation**: Scale across hardware with SVE support (**128-bit to 2048-bit vectors**).

***Runtime Vector-Length Awareness:** The SVE fast path is enabled only for systems with **vector lengths >= 256-bit**. Platforms with **128-bit SVE implementations** (where optimized **NEON/ASIMD** paths remain competitive) automatically fall back to existing standard primitives to avoid performance regressions from SVE setup overhead.

***Dual Primitive Support:** Includes optimized SVE paths for both memory clearing (**memzero**) and data movement (**memcpy**).

***Runtime Safety:** Automatic fallback to standard primitives on non-SVE hardware via **AT_HWCAP** feature detection.

***Ecosystem Impact:** Directly enhances PyTorch on ARM (which recently adopted mimalloc as default) by accelerating tensor lifecycle management on **ARMv9-A** hardware.

***Toolchain Compatibility (Compiler Support):** Adds compiler-safe SVE integration through compile-time feature detection and function-level target attributes (**target("+sve"**) / **target("sve")**), allowing mimalloc to preserve baseline AArch64 compatibility while selectively enabling optimized SVE code paths on supported GCC and Clang toolchains. Older or non-SVE-capable compilers automatically fall back to existing implementations.


## Key Performance Highlights

- **Instruction Efficiency**
  - Achieves up to **12.3% reduction in retired instructions** for large buffers (64KB+).
  - Uses a **2048B crossover threshold** to avoid regressions on small-object metadata paths.

- **Throughput Improvements**
  - Delivers consistent **4%–7% bandwidth gains** on AWS Graviton 3 (Neoverse-V1).
  - Achieved through **4× unrolled SVE vector loops** that better saturate the execution pipeline.

- **Branch Predictability**
  - Eliminates the scalar-loop “branch cliff” behavior on large copies.
  - Reduces **branch mispredictions by 80%+** for buffers ≥ 8KB.

- **Hardware-Aware Runtime Gating**
  - Dynamically detects available **SVE Vector Length (VL)** at runtime.
  - SVE fast path activates only on systems with **VL ≥ 256-bit**.
  - Safely falls back to optimized scalar implementations on 128-bit systems such as AWS Graviton 4.

- **Operational Efficiency**
  - Lower instruction counts and reduced pipeline stalls improve overall compute efficiency.
  - Results in lower **power-per-GB transferred** for high-density cloud and memory-intensive workloads.
  __________________________________________________________________________________________________________________________________
  
## **Benchmarking Environment**
## Full Performance Comparison: AArch64 SVE vs. OSS (Standard)

**Environment:** AWS Graviton 3 (Neoverse-V1), 32vcpu, SVE256 Hardware support | 100,000 iterations per size

| Size (B) | Logic  | Metric       | OSS (Std) | SVE (Opt) | Impact             |
|-----------|---------|---------------|------------|------------|--------------------|
| 128       | Scalar  | Throughput    | 47.12 GB/s | 47.51 GB/s | +0.8%              |
|           |         | Instructions  | 13.72M     | 15.33M     | +11.7% (Loss)*     |
|           |         | Br-Misses     | 31.2k      | 30.8k      | -1.2%              |
| 256       | Scalar  | Throughput    | 58.49 GB/s | 61.23 GB/s | +4.6%              |
|           |         | Instructions  | 16.92M     | 18.51M     | +9.4% (Loss)*      |
|           |         | Br-Misses     | 32.5k      | 32.1k      | -1.2%              |
| 512       | Scalar  | Throughput    | 77.05 GB/s | 78.07 GB/s | +1.3%              |
|           |         | Instructions  | 21.31M     | 22.89M     | +7.4% (Loss)*      |
|           |         | Br-Misses     | 33.1k      | 32.8k      | -0.9%              |
| 1024      | Scalar  | Throughput    | 76.75 GB/s | 77.68 GB/s | +1.2%              |
|           |         | Instructions  | 30.95M     | 32.54M     | +5.1% (Loss)*      |
|           |         | Br-Misses     | 32.1k      | 31.9k      | -0.6%              |
| 2048      | SVE     | Throughput    | 79.27 GB/s | 82.61 GB/s | +4.2% 🚀           |
|           |         | Instructions  | 50.15M     | 46.14M     | -8.0% 📉           |
|           |         | Br-Misses     | 34.8k      | 33.2k      | -4.6%              |
| 4096      | SVE     | Throughput    | 77.50 GB/s | 82.52 GB/s | +6.4%              |
|           |         | Instructions  | 88.54M     | 79.78M     | -9.9%              |
|           |         | Br-Misses     | 35.2k      | 34.1k      | -3.1%              |
| 8192      | SVE     | Throughput    | 79.67 GB/s | 82.70 GB/s | +3.8%              |
|           |         | Instructions  | 165.39M    | 147.11M    | -11.0%             |
|           |         | Br-Misses     | 188.4k     | 35.1k      | -81.3% ⚡          |
| 16384     | SVE     | Throughput    | 76.21 GB/s | 81.15 GB/s | +6.4%              |
|           |         | Instructions  | 324.12M    | 285.55M    | -11.9%             |
|           |         | Br-Misses     | 210.5k     | 38.2k      | -81.8% ⚡          |
| 65536     | SVE     | Throughput    | 74.82 GB/s | 79.91 GB/s | +6.8% 🚀           |
|           |         | Instructions  | 1.24B      | 1.08B      | -12.3% 📉          |
|           |         | Br-Misses     | 232.1k     | 44.8k      | -80.7% ⚡          |

_______________________________________________________________________________________________________________________________________
**Test script:**
fast_bench.cpp

## Benchmark Source

```cpp
#include <iostream>
#include <vector>
#include <chrono>
#include <cstring>

// This includes the entire mimalloc source into our benchmark
// Adjust this path to point to your mimalloc/src/static.c
#include "/home/maajid/mimalloc_build_apr28/mimalloc/src/static.c"

int main(int argc, char** argv) {
    size_t size = (argc > 1) ? std::stoull(argv[1]) : 512 * 1024 * 1024;
    int iterations = (argc > 2) ? std::stoi(argv[2]) : 50;
    
    void* buffer_a = mi_malloc(size);
    void* buffer_b = mi_malloc(size);

    if (!buffer_a || !buffer_b) return 1;

    // --- Benchmark Memzero ---
    auto start = std::chrono::high_resolution_clock::now();

    for (int i = 0; i < iterations; ++i) {
        _mi_memzero(buffer_a, size);
    }

    auto end = std::chrono::high_resolution_clock::now();

    std::chrono::duration<double> diff = end - start;

    std::cout << "Memzero Throughput: "
              << (double(size) * iterations) / diff.count() / 1e9
              << " GB/s" << std::endl;

    // --- Benchmark Memcpy ---
    start = std::chrono::high_resolution_clock::now();

    for (int i = 0; i < iterations; ++i) {
        _mi_memcpy(buffer_b, buffer_a, size);
    }

    end = std::chrono::high_resolution_clock::now();

    diff = end - start;

    std::cout << "Memcpy Throughput: "
              << (double(size) * iterations) / diff.count() / 1e9
              << " GB/s" << std::endl;

    mi_free(buffer_a);
    mi_free(buffer_b);

    return 0;
}
```

**Compile:**
g++ -O3 -Drestrict=__restrict -I/home/maajid/mimalloc_build_apr28/mimalloc/include fast_bench.cpp -lpthread -o bench_sve

**Test**
./bench_sve 2048 1  (Where, n = threshold size = 2048, iterations = 1)
_______________________________________________________________________________________________________________________________________
**Final Benchmarking Script:**
```bash
#!/bin/bash

# --- Paths to your libraries ---
OSS_LIB="/home/maajid/mimalloc_build_apr28/oss_build/mimalloc/out/release/libmimalloc.so"
SVE_LIB="/home/maajid/mimalloc_build_apr28/mimalloc/out/release/libmimalloc.so"

# Verify libraries exist
if [[ ! -f "$OSS_LIB" || ! -f "$SVE_LIB" ]]; then
    echo "Error: One or both libraries not found!"
    echo "OSS: $OSS_LIB"
    echo "SVE: $SVE_LIB"
    exit 1
fi

SIZES=(128 256 512 1024 2048 4096 8192 16384 32768 65536)
ITERS=100000

echo "Size(B)  | Build | GB/s    | Instructions | IPC  | Br-Miss | Insn Delta"
echo "----------------------------------------------------------------------------"

for SZ in "${SIZES[@]}"; do
  INS_OSS=0
  INS_SVE=0

  for BUILD in "oss" "sve"; do
    if [ "$BUILD" == "oss" ]; then
      MIMALLOC_PATH=$OSS_LIB
    else
      MIMALLOC_PATH=$SVE_LIB
    fi

    # Execute with LD_PRELOAD
    OUT=$(LD_PRELOAD=$MIMALLOC_PATH perf stat -x, -e instructions,cycles,branch-misses \
          taskset -c 1 ./bench_$BUILD $SZ $ITERS 2>&1)

    # Parse metrics, filtering out debug messages
    INS=$(echo "$OUT" | grep "instructions" | cut -d, -f1)
    CYC=$(echo "$OUT" | grep "cycles" | cut -d, -f1)
    BRM=$(echo "$OUT" | grep "branch-misses" | cut -d, -f1)
    IPC=$(echo "scale=2; $INS / $CYC" | bc)

    # Extract throughput from binary output (ignore debug lines)
    GBS=$(echo "$OUT" | grep "Throughput" | grep -v "DEBUG" | tail -n 1 | awk '{print $3}')

    if [ "$BUILD" == "oss" ]; then
      INS_OSS=$INS
    else
      INS_SVE=$INS
    fi

    printf "%-8s | %-5s | %-7s | %-12s | %-4s | %-8s | " \
            "$SZ" "$BUILD" "$GBS" "$INS" "$IPC" "$BRM"

    if [ "$BUILD" == "sve" ]; then
      DIFF=$(echo "$INS_SVE - $INS_OSS" | bc)
      if [ $DIFF -lt 0 ]; then
        printf "\e[32m%10d (Win)\e[0m\n" "$DIFF"
      else
        printf "\e[31m+%10d (Loss)\e[0m\n" "$DIFF"
      fi
    else
      echo ""
    fi
  done
  echo "----------------------------------------------------------------------------"
done
```