### PR TITLE
Fix realloc crash when realloc is the first allocation on a thread (#1304)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -786,7 +786,7 @@ if (MI_BUILD_TESTS)
   enable_testing()
 
   # static link tests
-  foreach(TEST_NAME api api-fill stress)
+  foreach(TEST_NAME api api-fill stress realloc-thread)
     add_executable(mimalloc-test-${TEST_NAME} test/test-${TEST_NAME}.c)
     target_compile_definitions(mimalloc-test-${TEST_NAME} PRIVATE ${mi_defines})
     target_compile_options(mimalloc-test-${TEST_NAME} PRIVATE ${mi_cflags})

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -375,6 +375,9 @@ void* _mi_theap_realloc_zero(mi_theap_t* theap, void* p, size_t newsize, bool ze
     if (usable_pre!=NULL) { *usable_pre = mi_page_usable_block_size(page); }
   }
   if mi_unlikely(newsize<=size && newsize>=(size/2) && newsize>0  // note: newsize must be > 0 or otherwise we return NULL for realloc(NULL,0)
+                  #if MI_THEAP_INITASNULL
+                  && mi_theap_is_initialized(theap)  // the default theap can be NULL if realloc is the first allocation on a thread; skip the in-place check then (issue #1304)
+                  #endif
                   && mi_page_heap(page)==_mi_theap_heap(theap))             // and within the same heap
   {
     mi_assert_internal(p!=NULL);

--- a/test/test-realloc-thread.c
+++ b/test/test-realloc-thread.c
@@ -1,0 +1,97 @@
+/* ----------------------------------------------------------------------------
+Copyright (c) 2018-2025, Microsoft Research, Daan Leijen
+This is free software; you can redistribute it and/or modify it under the
+terms of the MIT license. A copy of the license can be found in the file
+"LICENSE" at the root of this distribution.
+-----------------------------------------------------------------------------*/
+
+/*
+Regression test for issue #1304: a `realloc` that is the *first* mimalloc call
+on a freshly created thread must not crash.
+
+On platforms with a fixed or dynamic TLS slot (macOS, Windows, OpenBSD) the
+thread-local default theap is NULL until the first allocation lazily
+initializes it (`MI_THEAP_INITASNULL`). `mi_malloc` tolerates a NULL theap, but
+the in-place fast path of `_mi_theap_realloc_zero` used to evaluate
+`_mi_theap_heap(theap)` unconditionally, dereferencing the NULL theap and
+segfaulting when a fresh thread's first call was an in-place-fitting
+`mi_realloc` of a block allocated on another thread.
+See https://github.com/microsoft/mimalloc/issues/1304
+*/
+
+#include <stdbool.h>
+#include <string.h>
+#include <mimalloc.h>
+#include "testhelper.h"
+
+// ---------------------------------------------------------------------------
+// Minimal portable launcher: run `body` once on a brand new thread and join.
+// Threads run sequentially (each joined before the next), so a file-scope
+// callback pointer is sufficient and keeps the worker's first statement the
+// allocation under test.
+// ---------------------------------------------------------------------------
+static void (*thread_body)(void);
+
+#if defined(_WIN32)
+#include <windows.h>
+static DWORD WINAPI thread_entry(LPVOID arg) { (void)arg; thread_body(); return 0; }
+static void run_in_fresh_thread(void (*body)(void)) {
+  thread_body = body;
+  HANDLE h = CreateThread(NULL, 0, &thread_entry, NULL, 0, NULL);
+  WaitForSingleObject(h, INFINITE);
+  CloseHandle(h);
+}
+#else
+#include <pthread.h>
+static void* thread_entry(void* arg) { (void)arg; thread_body(); return NULL; }
+static void run_in_fresh_thread(void (*body)(void)) {
+  thread_body = body;
+  pthread_t t;
+  pthread_create(&t, NULL, &thread_entry, NULL);
+  pthread_join(t, NULL);
+}
+#endif
+
+// ---------------------------------------------------------------------------
+// Shared state between the main thread and the worker.
+// ---------------------------------------------------------------------------
+static void* shared_block;     // allocated on the main thread, realloc'd on the worker
+static void* worker_result;    // pointer returned by the worker's realloc
+static bool  worker_content_ok;
+
+// in-place-fitting realloc (48 in [32,64]): this is the branch that used to
+// dereference the NULL theap on a fresh thread before the fix.
+static void body_realloc_inplace_first(void) {
+  worker_result = mi_realloc(shared_block, 48);   // <-- FIRST mimalloc call on this thread
+  worker_content_ok = (worker_result != NULL && memcmp(worker_result, "1304", 4) == 0);
+}
+
+// growing realloc as the first call: always took the slow path, but exercise it too.
+static void body_realloc_grow_first(void) {
+  worker_result = mi_realloc(shared_block, 4096); // <-- FIRST mimalloc call on this thread
+  worker_content_ok = (worker_result != NULL && memcmp(worker_result, "1304", 4) == 0);
+}
+
+int main(void) {
+  mi_option_disable(mi_option_verbose);
+
+  // in-place-fitting realloc as the first allocation on a fresh thread (issue #1304)
+  shared_block = mi_malloc(64);
+  memcpy(shared_block, "1304", 4);
+  worker_result = NULL; worker_content_ok = false;
+  run_in_fresh_thread(&body_realloc_inplace_first);
+  CHECK("realloc-inplace-first-no-crash", worker_result != NULL);
+  CHECK("realloc-inplace-first-content", worker_content_ok);
+  mi_free(worker_result);
+
+  // growing realloc as the first allocation on a fresh thread
+  shared_block = mi_malloc(64);
+  memcpy(shared_block, "1304", 4);
+  worker_result = NULL; worker_content_ok = false;
+  run_in_fresh_thread(&body_realloc_grow_first);
+  CHECK("realloc-grow-first-no-crash", worker_result != NULL);
+  CHECK("realloc-grow-first-content", worker_content_ok);
+  mi_free(worker_result);
+
+  return print_test_summary();
+}


### PR DESCRIPTION
Found this while running Julia with mimalloc 3. Seems like just a missing guard.

<details>
<summary>AI Slop ahead</summary>

## Summary

Fixes #1304 — a crash when `realloc` is the **first** mimalloc call on a freshly created thread.

On platforms with a fixed or dynamic TLS slot (macOS, Windows, OpenBSD), the thread-local default `theap` is `NULL` until the first allocation lazily initializes it (`MI_THEAP_INITASNULL`). Every `malloc` path tolerates a `NULL` theap and routes to the generic lazy-init path, but the **in-place fast path** of `_mi_theap_realloc_zero` evaluated `_mi_theap_heap(theap)` unconditionally:

```c
if mi_unlikely(newsize<=size && newsize>=(size/2) && newsize>0
               && mi_page_heap(page)==_mi_theap_heap(theap))   // derefs theap->heap
```

`_mi_theap_heap()` does `mi_atomic_load_acquire(&theap->heap)`, so when a fresh thread's first call is an in-place-fitting `mi_realloc` of a block allocated on **another** thread, `theap == NULL` and this dereferences a null pointer → SIGSEGV. (`mi_malloc` does not hit this because all malloc paths already guard `theap != NULL` under `MI_THEAP_INITASNULL`.)

## Reproduction

First allocator call on a brand-new thread is an in-place-fitting realloc of a block from another thread:

```c
void* p = mi_malloc(64);                 // main thread
// ... on a fresh worker thread, with no prior mimalloc call:
void* q = mi_realloc(p, 48);             // 48 in [32,64] -> in-place candidate -> deref NULL theap
```

`lldb` on macOS arm64 (v3.3.2): `EXC_BAD_ACCESS (code=1, address=0x8)` in `_mi_theap_realloc_zero`, instruction `ldapr x8, [x8]` with `x8 == 0` — i.e. the acquire-load of `theap->heap` (offset `0x8`) through a NULL theap. This matches the crash frame reported in #1304 (libcurl/libopenssl + many `std::async` workers).

## Fix

Guard the in-place check with `mi_theap_is_initialized(theap)` under `#if MI_THEAP_INITASNULL`:

```c
  if mi_unlikely(newsize<=size && newsize>=(size/2) && newsize>0
                  #if MI_THEAP_INITASNULL
                  && mi_theap_is_initialized(theap)
                  #endif
                  && mi_page_heap(page)==_mi_theap_heap(theap))
```

A `NULL` (or partially-initialized) theap then falls through to `mi_theap_umalloc`, which lazily initializes the thread heap, copies, and frees the old block — exactly as `mi_malloc` already does. This is also semantically correct: if the thread has no heap yet, `p` necessarily belongs to a *different* heap, so the "same heap" in-place check would be false regardless.

`mi_theap_is_initialized` (rather than a bare `theap != NULL`) additionally covers the `theap != NULL && heap == NULL` partial-init window. The guard compiles out entirely on the `THREAD_LOCAL` model (Linux), where the default theap is never `NULL`, so there is **no** added cost on that hot path.

## Test

Adds `test/test-realloc-thread.c` (registered under `MI_BUILD_TESTS`): an in-place-fitting and a growing `realloc` as the first allocation on a fresh thread. It **SIGSEGVs without this patch** (exit 139) and passes with it.

Verified on macOS arm64 (`MI_TLS_MODEL_FIXED_SLOT`): `test-realloc-thread` 4/4, `test-api` 37/0, `test-api-fill` 17/0, `test-stress` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>


