### PR TITLE
fix(osx): implement introspect.reinit_lock to avoid fork() crash

### DIFF
--- a/src/prim/osx/alloc-override-zone.c
+++ b/src/prim/osx/alloc-override-zone.c
@@ -174,6 +174,14 @@ static boolean_t intro_zone_locked(malloc_zone_t* zone) {
   return false;
 }
 
+// Required whenever the zone advertises version >= 9: macOS calls this from the
+// atfork_child handler (_malloc_fork_child) without a NULL check. mimalloc keeps
+// no zone-level locks that need reinitializing after fork, so a no-op is safe.
+// Leaving it NULL makes the forked child jump to address 0 and crash in fork().
+static void intro_reinit_lock(malloc_zone_t* zone) {
+  MI_UNUSED(zone);
+}
+
 
 /* ------------------------------------------------------
   At process start, override the default allocator
@@ -198,6 +206,7 @@ static malloc_introspection_t mi_introspect = {
 #if defined(MAC_OS_X_VERSION_10_6) && (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_6) && !defined(__ppc__)
   .statistics = &intro_statistics,
   .zone_locked = &intro_zone_locked,
+  .reinit_lock = &intro_reinit_lock,
 #endif
 };
 


### PR DESCRIPTION
Re-submission of #1311 against `dev` as requested by @daanx.

Same commit, identical diff. Closing #1311.

cc @daanx

---

The macOS malloc zone advertises version >= 9, for which libmalloc invokes
`introspect->reinit_lock` from the atfork_child handler (`_malloc_fork_child`)
without a NULL check. The introspection struct left `reinit_lock` unset (NULL),
so any `fork()` in a process that statically links the mimalloc zone made the
child jump to address 0 and crash (EXC_BAD_ACCESS at 0x0) on macOS 15.

Provide a no-op `reinit_lock`: mimalloc has no zone-level locks to reinitialize
after fork.
