### PR TITLE
Fix format specifiers for long err in numa bind warning message

### DIFF
--- a/src/prim/unix/prim.c
+++ b/src/prim/unix/prim.c
@@ -562,7 +562,7 @@ int _mi_prim_alloc_huge_os_pages(void* hint_addr, size_t size, int numa_node, bo
     long err = mi_prim_mbind(*addr, size, MPOL_PREFERRED, &numa_mask, 8*MI_INTPTR_SIZE, 0);
     if (err != 0) {
       err = errno;
-      _mi_warning_message("failed to bind huge (1GiB) pages to numa node %d (error: %d (0x%x))\n", numa_node, err, err);
+      _mi_warning_message("failed to bind huge (1GiB) pages to numa node %d (error: %ld (0x%lx))\n", numa_node, err, err);
     }
   }
   return (*addr != NULL ? 0 : errno);


### PR DESCRIPTION
This was reported by CodeQL in CPython (we bundle a copy).

There are two more alterts in `_mi_arena_free`:

https://github.com/microsoft/mimalloc/blob/fef6b0dd70f9d7fa0750b0d0b9fbb471203b94cd/src/arena.c#L705

https://github.com/microsoft/mimalloc/blob/fef6b0dd70f9d7fa0750b0d0b9fbb471203b94cd/src/arena.c#L710

The 24-byte `mi_memid_t` struct `memid` is passed to a `%zx` (`size_t`) format specifier which is UB under CodeQL's `cpp/wrong-type-format-argument` rule. I'm not familiar with `mimalloc` to know how to fix these :-)