### PR TITLE
Add opt-in MI_SINGLE_THREADED specialization for the free fast path

### DIFF
--- a/src/free.c
+++ b/src/free.c
@@ -153,7 +153,14 @@ static inline void mi_free_ex(void* p, size_t* usable) mi_attr_noexcept
   mi_segment_t* const segment = mi_checked_ptr_segment(p,"mi_free");
   if mi_unlikely(segment==NULL) return;
 
+  #if defined(MI_SINGLE_THREADED) && (MI_SINGLE_THREADED)
+  // Single-threaded specialization (ExGen-Malloc, CAL'25): in a program that only ever
+  // uses mimalloc from one thread, every block is thread-local, so we can skip the
+  // thread-id TLS read + atomic load + compare on every free.
+  const bool is_local = true;
+  #else
   const bool is_local = (_mi_prim_thread_id() == mi_atomic_load_relaxed(&segment->thread_id));
+  #endif
   mi_page_t* const page = _mi_segment_page_of(segment, p);
   if (usable!=NULL) { *usable = mi_page_usable_block_size(page); }
   


### PR DESCRIPTION
## Summary

In a program that only ever uses mimalloc from a single thread, every freed block is guaranteed to be thread-local, so the per-free thread-ownership check in `mi_free_ex` — a thread-id TLS read, a relaxed atomic load of `segment->thread_id`, and a compare — is redundant.

This PR adds an **opt-in, off-by-default** compile-time switch `-DMI_SINGLE_THREADED=1` that forces `is_local = true` and skips that check on the free fast path. It is motivated by recent literature on specializing general-purpose allocators for single-threaded use (e.g. ExGen-Malloc, *"Old is Gold"*, IEEE CAL'25).

```c
#if defined(MI_SINGLE_THREADED) && (MI_SINGLE_THREADED)
  const bool is_local = true;
#else
  const bool is_local = (_mi_prim_thread_id() == mi_atomic_load_relaxed(&segment->thread_id));
#endif
```

## Safety / default build

The default build is **unchanged** — the `#else` path is identical to the previous code. The flag is a single-thread-only promise by the embedder (multi-threaded use is out of contract, exactly like other single-thread allocator builds). With the flag **off**, the full test suite (including the multi-threaded `test-stress` and `test-stress-dynamic`) passes.

## Measurements

mimalloc-bench, single-threaded, pinned to one core, interleaved median-of-11 (baseline = current `dev`):

| benchmark | baseline | MI_SINGLE_THREADED | delta |
|---|---|---|---|
| alloc-test (1 thread) | 4.62 s | 4.60 s | **-0.43%** |
| sh6bench | 1.67 s | 1.66 s | -0.3% |
| cfrac | 7.59 s | 7.58 s | ~0% (compute-bound) |
| espresso | 6.24 s | 6.23 s | ~0% (compute-bound) |

`perf stat` on alloc-test confirms the mechanism: **~2.5% fewer branches** (~50M, the eliminated per-free ownership branch) and **~1.1% fewer instructions**. `cfrac`/`espresso` stdout is byte-identical to baseline.

The gain is modest but consistent on allocation-heavy single-threaded workloads, with zero cost or risk to the default multi-threaded build.