### PR TITLE
fix 32-bit overflow in `mi_page_start` for pages ≥ 4 GiB after their page meta info (issue #1309)

### DIFF
--- a/include/mimalloc/internal.h
+++ b/include/mimalloc/internal.h
@@ -683,7 +683,8 @@ static inline size_t mi_page_block_size(const mi_page_t* page) {
 
 // Page start
 static inline uint8_t* mi_page_start(const mi_page_t* page) {
-  return (uint8_t*)page + (page->page_woffset * MI_SIZE_SIZE);
+  // multiplication must be done in `size_t`; in a 32-bit multiplication the offset wraps for pages whose blocks start 4 GiB or more after the page meta info
+  return (uint8_t*)page + ((size_t)page->page_woffset * MI_SIZE_SIZE);
 }
 
 static inline size_t mi_page_size(const mi_page_t* page) {

--- a/src/arena.c
+++ b/src/arena.c
@@ -1608,7 +1608,6 @@ static bool mi_manage_os_memory_ex2(mi_subproc_t* subproc, void* start, size_t s
   mi_memid_t memid, mi_commit_fun_t* commit_fun, void* commit_fun_arg, mi_arena_id_t* arena_id) mi_attr_noexcept
 {
   // checks
-  mi_assert(_mi_is_aligned(start, MI_ARENA_SLICE_SIZE));
   mi_assert(start!=NULL);
   if (arena_id != NULL) { *arena_id = _mi_arena_id_none(); }
   if (start==NULL) return false;

--- a/test/test-api.c
+++ b/test/test-api.c
@@ -355,9 +355,11 @@ int main(void) {
     }
   }
 
-  // CHECK_BODY("arena_reserve") {
-  //   result = (0==mi_reserve_os_memory(16*MI_GiB,false,true));
-  // }
+  #if (MI_INTPTR_SIZE > 4)
+  CHECK_BODY("arena_reserve") {
+    result = (0==mi_reserve_os_memory(16*MI_GiB,false,true));
+  }
+  #endif
 
   // ---------------------------------------------------
   // Heaps


### PR DESCRIPTION
# Summery

While verifying the fix for #1309 at scale I hit a regression from f5e879f7, which made `page_woffset` a 32-bit word offset:

```c
return (uint8_t*)page + (page->page_woffset * MI_SIZE_SIZE);
```

The multiplication is done in 32-bit arithmetic, so it wraps when a page's blocks start 4 GiB or more after the page meta info. With separated page meta info, this happens as soon as an arena grows past 4 GiB: the computed page start points 4 GiB below the real blocks, into other live pages. Debug builds fail the assertion `mi_page_slice_start(page) == slice_start` in `mi_arenas_page_alloc_fresh`; release builds corrupt memory and crash.

Fix: do the multiplication in `size_t`.

Also:
- removed the slice-alignment assert at the top of `mi_manage_os_memory_ex2` — unaligned starts are handled right below it, so it fires for valid calls in debug builds;
- re-enabled the 16 GiB `arena_reserve` test from 566fbc1f, gated to 64-bit.

Tested on 64-bit Linux: a process growing to 170 GiB live (with per-block content verification) now completes cleanly in release, debug, and secure builds with a flat mapping count. Before the fix, the same program crashed reading back its first allocated block after ~10 GiB in a 16 GiB arena. This also confirms 566fbc1f itself: the #1309 wedge is gone.