### PR TITLE
Advise MADV_HUGEPAGE independently of allow_large

### DIFF
--- a/src/prim/unix/prim.c
+++ b/src/prim/unix/prim.c
@@ -389,7 +389,7 @@ static void* unix_mmap(void* addr, size_t size, size_t try_alignment, int protec
     *is_large = false;
     p = unix_mmap_prim_aligned(addr, size, try_alignment, protect_flags, flags, fd);
     #if !defined(MI_NO_THP)
-    if (p != NULL && allow_large && mi_option_is_enabled(mi_option_allow_thp) && _mi_os_canuse_large_page(size, try_alignment)) {
+    if (p != NULL && mi_option_is_enabled(mi_option_allow_thp) && _mi_os_canuse_large_page(size, try_alignment)) {
       #if defined(MADV_HUGEPAGE)
       // Many Linux systems don't allow MAP_HUGETLB but they support instead
       // transparent huge pages (THP). Generally, it is not required to call `madvise` with MADV_HUGE


### PR DESCRIPTION
On Linux with the default distro THP setting (`madvise`), memory becomes eligible for transparent huge pages only if the process calls `madvise(MADV_HUGEPAGE)` on it. mimalloc gates that advise on the caller's `allow_large` parameter, which callers derive from segment laziness and which primarily exists to gate `MAP_HUGETLB`. The
hugetlbfs half of that gate makes sense (hugetlb pages are physically committed at map time), but THP pages materialize on fault, so tying the two together means huge objects (the OS singleton path) and each thread's first segment are never THP-eligible even with `MIMALLOC_ALLOW_THP=1`, which is the default.

This PR makes the advise depend only on `mi_option_allow_thp`, leaving the hugetlbfs gate unchanged. dev3 effectively behaves this way already (singleton pages are committed eagerly and `allow_large` no longer depends on laziness), so this can be seen as aligning dev2 with dev3 semantics.

Motivating case: in the mold linker, the largest data structures (multi-gigabyte symbol and relocation arrays) allocate through the huge-object path. On a Chromium debug link, about 5.7 GiB of a 14.5 GiB heap stayed on 4 KiB pages; with this change the heap is almost fully huge-page backed, linking is about 2% faster in mold's default mode and 15% faster in its single-process mode, where process exit is user-visible and tearing down 2 MiB folios is far cheaper than millions of 4 KiB folios.