### PR TITLE
fix missing semicolon after mi_track_done() (ETW build failure)

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -1172,7 +1172,7 @@ void mi_cdecl mi_process_done(void) mi_attr_noexcept {
   #endif
 
   // done with tracking tools
-  mi_track_done()
+  mi_track_done();
 
   // Forcefully release all retained memory; this can be dangerous in general if overriding regular malloc/free
   // since after process_done there might still be other code running that calls `free` (like at_exit routines,


### PR DESCRIPTION
`mi_track_done()` in `mi_process_done()` (src/init.c) is missing a trailing semicolon.

 When ETW tracking is enabled (`-DMI_TRACK_ETW=1`), the macro expands to a real function call (`EventUnregistermicrosoft_windows_mimalloc()`), which then lacks a statement terminator. This causes a hard compile error
on MSVC:

    src/init.c: error C2143: syntax error: missing ';' before 'if'
The bug is latent in the default build because without `MI_TRACK_ETW`, the macro expands to nothing, so no statement is
emitted and no semicolon is needed. It reproduces on VS2017/VS2019/VS2022 whenever ETW tracking is enabled.
Fix: add the missing `;` terminator.

