### PR TITLE
Randomize cache index for singleton allocations

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -196,8 +196,38 @@ extern inline void* _mi_heap_malloc_zero_ex(mi_heap_t* heap, size_t size, bool z
   }
 }
 
+// Large singleton pages start at slice boundaries. Returning that address
+// unchanged for a run of equally-sized allocations can map every object to
+// the same cache sets. Use some of the size-class slack to vary the cache
+// index without reserving any additional memory.
+static void* mi_heap_malloc_cache_index_randomize(mi_heap_t* heap, void* p, size_t size) {
+  #if MI_TRACK_ENABLED
+  MI_UNUSED(heap); MI_UNUSED(size);
+  return p;
+  #else
+  if (p == NULL) return NULL;
+  mi_page_t* const page = _mi_ptr_page(p);
+  if (page->reserved != 1 || mi_page_has_aligned(page)) return p;
+
+  const size_t bsize = mi_page_usable_block_size(page);
+  const size_t slack = (bsize >= size ? bsize - size : 0);
+  const size_t cache_line = 64;
+  const size_t max_cache_offset = 63 * cache_line;
+  if (slack < cache_line) return p;
+
+  const size_t offset_count = 1 + ((slack < max_cache_offset ? slack : max_cache_offset) / cache_line);
+  const size_t offset = (_mi_heap_random_next(heap) % offset_count) * cache_line;
+  if (offset == 0) return p;
+
+  mi_page_set_has_aligned(page, true);
+  _mi_padding_shrink(page, (mi_block_t*)p, offset + size);
+  return (uint8_t*)p + offset;
+  #endif
+}
+
 extern inline void* _mi_heap_malloc_zero(mi_heap_t* heap, size_t size, bool zero) mi_attr_noexcept {
-  return _mi_heap_malloc_zero_ex(heap, size, zero, 0, NULL);
+  void* const p = _mi_heap_malloc_zero_ex(heap, size, zero, 0, NULL);
+  return mi_heap_malloc_cache_index_randomize(heap, p, size);
 }
 
 mi_decl_nodiscard extern inline mi_decl_restrict void* mi_heap_malloc(mi_heap_t* heap, size_t size) mi_attr_noexcept {

--- a/src/free.c
+++ b/src/free.c
@@ -504,6 +504,14 @@ void _mi_padding_shrink(const mi_page_t* page, const mi_block_t* block, const si
   mi_track_mem_defined(padding,sizeof(mi_padding_t));
   padding->delta = (uint32_t)new_delta;
   mi_track_mem_noaccess(padding,sizeof(mi_padding_t));
+  #if MI_PADDING_CHECK
+  // The usable prefix grew, so move the overflow-detection bytes with it.
+  uint8_t* fill = (uint8_t*)block + bsize - new_delta;
+  const size_t maxpad = (new_delta > MI_MAX_ALIGN_SIZE ? MI_MAX_ALIGN_SIZE : new_delta);
+  mi_track_mem_defined(fill, maxpad);
+  for (size_t i = 0; i < maxpad; i++) { fill[i] = MI_DEBUG_PADDING; }
+  mi_track_mem_noaccess(fill, maxpad);
+  #endif
 }
 #else
 static size_t mi_page_usable_size_of(const mi_page_t* page, const mi_block_t* block, bool is_guarded) {

--- a/test/test-api.c
+++ b/test/test-api.c
@@ -102,6 +102,26 @@ int main(void) {
     void* p = mi_malloc(67108872);
     mi_free(p);
   };
+  CHECK_BODY("malloc-large-cache-index") { // see issue #1121
+    #if (MI_TRACK_VALGRIND || MI_TRACK_ASAN || MI_TRACK_ETW)
+    result = true; // cache-index randomization is disabled with external trackers
+    #else
+    const size_t count = 64;
+    const size_t size = 64 * 1024 * sizeof(float) + sizeof(float);
+    void* blocks[64];
+    uintptr_t first_index = 0;
+    bool varied = false;
+    for (size_t i = 0; i < count; i++) {
+      blocks[i] = mi_malloc(size);
+      assert(blocks[i] != NULL);
+      const uintptr_t index = (uintptr_t)blocks[i] % 4096;
+      if (i == 0) { first_index = index; }
+      else if (index != first_index) { varied = true; }
+    }
+    for (size_t i = 0; i < count; i++) { mi_free(blocks[i]); }
+    result = varied;
+    #endif
+  };
 
   // ---------------------------------------------------
   // Extended


### PR DESCRIPTION
Fixes #1121.

## What changed

- Randomize the cache index of normal allocations backed by singleton pages.
- Use at most 4032 bytes of existing size-class slack, in 64-byte increments, so the change does not reserve additional memory.
- Keep externally tracked allocations unchanged.
- Move debug padding bytes when the usable prefix grows.
- Add an API regression test for repeated allocations of the size reported in #1121.

## Root cause

Large singleton allocations start on 64 KiB slice boundaries. A sequence of equally sized allocations can consequently map corresponding elements of every allocation to the same cache sets, causing severe conflict misses even though allocation itself is outside the timed region.

For the #1121 reproducer, all 1000 allocations were 64 KiB aligned before this change. With cache-index randomization, typically 10–24 of 1000 retain that alignment.

## Results

Measured on an Intel Core i5-1235U, pinned to one CPU, using release builds from commit `a3ca0e5e`:

| Allocator | Median runtime |
| --- | ---: |
| glibc | 0.703 s |
| mimalloc before | 1.340 s |
| mimalloc after | 0.269 s |

The mimalloc virtual allocation span remains 345 MiB before and after. A separate loop of 100,000 allocation/free pairs at the affected size remained approximately 0.044 s both before and after.

Hardware performance counters were unavailable on the test host because `perf_event_paranoid=4`.

## Validation

- API suite, debug build: 44/44 passed
- API suite, release build: 44/44 passed
- Multithreaded stress test: passed (`4 5 2`)
- `git diff --check`: passed
