### PR TITLE
Allow build for Universal Windows Platform

### DIFF
--- a/src/prim/windows/prim.c
+++ b/src/prim/windows/prim.c
@@ -13,9 +13,9 @@ terms of the MIT license. A copy of the license can be found in the file
 #include <stdio.h>   // fputs, stderr
 #include <stdlib.h>  // atexit
 
-// xbox has no console IO
-#if !defined(WINAPI_FAMILY_PARTITION) || WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP | WINAPI_PARTITION_SYSTEM)
-#define MI_HAS_CONSOLE_IO
+// Xbox has no console IO and cannot use LoadLibrary
+#if !defined(WINAPI_FAMILY_PARTITION) || WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM)
+#define MI_WINDOWS_DESKTOP
 #endif
 
 //---------------------------------------------
@@ -77,6 +77,15 @@ static PGetLargePageMinimum pGetLargePageMinimum = NULL;
 
 // Available after Windows XP
 typedef BOOL (__stdcall *PGetPhysicallyInstalledSystemMemory)( PULONGLONG TotalMemoryInKilobytes );
+
+inline static HMODULE _mi_prim_loadlibrary(const TCHAR* library)
+{
+#ifdef MI_WINDOWS_DESKTOP
+    return LoadLibrary(library);
+#else
+    return LoadPackagedLibrary(library, 0);
+#endif
+}
 
 
 //---------------------------------------------
@@ -148,7 +157,7 @@ void _mi_prim_mem_init( mi_os_mem_config_t* config )
 
   // get the VirtualAlloc2 function
   HINSTANCE  hDll;
-  hDll = LoadLibrary(TEXT("kernelbase.dll"));
+  hDll = _mi_prim_loadlibrary(TEXT("kernelbase"));
   if (hDll != NULL) {
     // use VirtualAlloc2FromApp if possible as it is available to Windows store apps
     pVirtualAlloc2 = (PVirtualAlloc2)(void (*)(void))GetProcAddress(hDll, "VirtualAlloc2FromApp");
@@ -156,13 +165,13 @@ void _mi_prim_mem_init( mi_os_mem_config_t* config )
     FreeLibrary(hDll);
   }
   // NtAllocateVirtualMemoryEx is used for huge page allocation
-  hDll = LoadLibrary(TEXT("ntdll.dll"));
+  hDll = _mi_prim_loadlibrary(TEXT("ntdll"));
   if (hDll != NULL) {
     pNtAllocateVirtualMemoryEx = (PNtAllocateVirtualMemoryEx)(void (*)(void))GetProcAddress(hDll, "NtAllocateVirtualMemoryEx");
     FreeLibrary(hDll);
   }
   // Try to use Win7+ numa API
-  hDll = LoadLibrary(TEXT("kernel32.dll"));
+  hDll = _mi_prim_loadlibrary(TEXT("kernel32"));
   if (hDll != NULL) {
     pGetCurrentProcessorNumberEx = (PGetCurrentProcessorNumberEx)(void (*)(void))GetProcAddress(hDll, "GetCurrentProcessorNumberEx");
     pGetNumaProcessorNodeEx = (PGetNumaProcessorNodeEx)(void (*)(void))GetProcAddress(hDll, "GetNumaProcessorNodeEx");
@@ -544,7 +553,7 @@ void _mi_prim_process_info(mi_process_info_t* pinfo)
 
   // load psapi on demand
   mi_atomic_do_once {
-    HINSTANCE hDll = LoadLibrary(TEXT("psapi.dll"));
+    HINSTANCE hDll = _mi_prim_loadlibrary(TEXT("psapi"));
     if (hDll != NULL) {
       pGetProcessMemoryInfo = (PGetProcessMemoryInfo)(void (*)(void))GetProcAddress(hDll, "GetProcessMemoryInfo");
       // FreeLibrary(hDll);  // don't free
@@ -577,7 +586,7 @@ void _mi_prim_out_stderr( const char* msg )
     static bool hconIsConsole = false;
     if (hcon == INVALID_HANDLE_VALUE) {
       hcon = GetStdHandle(STD_ERROR_HANDLE);
-      #ifdef MI_HAS_CONSOLE_IO
+      #ifdef MI_WINDOWS_DESKTOP
       CONSOLE_SCREEN_BUFFER_INFO sbi;
       hconIsConsole = ((hcon != INVALID_HANDLE_VALUE) && GetConsoleScreenBufferInfo(hcon, &sbi));
       #endif
@@ -586,7 +595,7 @@ void _mi_prim_out_stderr( const char* msg )
     if (len > 0 && len < UINT32_MAX) {
       DWORD written = 0;
       if (hconIsConsole) {
-        #ifdef MI_HAS_CONSOLE_IO
+        #ifdef MI_WINDOWS_DESKTOP
         WriteConsoleA(hcon, msg, (DWORD)len, &written, NULL);
         #endif
       }
@@ -649,7 +658,7 @@ bool _mi_prim_random_buf(void* buf, size_t buf_len) {
   mi_assert(buf_len <= ULONG_MAX);
   if (buf_len > ULONG_MAX) return false;
   mi_atomic_do_once {
-    HINSTANCE hDll = LoadLibrary(TEXT("bcrypt.dll"));
+    HINSTANCE hDll = _mi_prim_loadlibrary(TEXT("bcrypt"));
     if (hDll != NULL) {
       pBCryptGenRandom = (PBCryptGenRandom)(void (*)(void))GetProcAddress(hDll, "BCryptGenRandom");
       // FreeLibrary(hDll);  // don't free


### PR DESCRIPTION
Allow build for Xbox Apps (UWP).

Currently `src/prim/windows/prim.c` has some patches but only covers Xbox Games (not Apps).

`LoadLibray` cannot be used in UWP apps, replaced with `LoadPackagedLibrary`.

Also `WINAPI_PARTITION_APP` is not defined for Xbox Games but is defined for Xbox Apps, then is not enough to cover all cases: console IO is also not available in Xbox Apps.

This is also fixed.

Note that `WINAPI_PARTITION_APP` is also defined when compile for Desktop then is not usable for differentiate Desktop / UWP.

