### PR TITLE
Fix/mi secure 2 page extend

### DIFF
--- a/src/alloc-aligned.c
+++ b/src/alloc-aligned.c
@@ -97,6 +97,11 @@ static mi_decl_noinline void* mi_heap_malloc_zero_aligned_at_overalloc(mi_heap_t
   void* aligned_p = (void*)((uintptr_t)p + adjust);
   if (aligned_p != p) {
     mi_page_set_has_aligned(page, true);
+    if (usable!=NULL) { 
+      mi_assert_internal(*usable > adjust);
+      if (*usable > adjust) { *usable = *usable - adjust; }
+      mi_assert_internal(*usable >= size);
+    }
     #if MI_GUARDED
     // set tag to aligned so mi_usable_size works with guard pages
     if (adjust >= sizeof(mi_block_t)) {

--- a/src/alloc-aligned.c
+++ b/src/alloc-aligned.c
@@ -176,7 +176,7 @@ static void* mi_heap_malloc_zero_aligned_at(mi_heap_t* const heap, const size_t 
   // note: we don't require `size > offset`, we just guarantee that the address at offset is aligned regardless of the allocated size.
   if mi_unlikely(alignment == 0 || !_mi_is_power_of_two(alignment)) { // require power-of-two (see <https://en.cppreference.com/w/c/memory/aligned_alloc>)
     #if MI_DEBUG > 0
-    _mi_error_message(EOVERFLOW, "aligned allocation requires the alignment to be a power-of-two (size %zu, alignment %zu)\n", size, alignment);
+    _mi_error_message(EOVERFLOW, "aligned allocation requires the alignment to be a power-of-two (size %zu, alignment %zu, offset %zu)\n", size, alignment, offset);
     #endif
     return NULL;
   }
@@ -283,12 +283,17 @@ mi_decl_nodiscard mi_decl_restrict void* mi_calloc_aligned(size_t count, size_t 
 // ------------------------------------------------------
 
 static void* mi_heap_realloc_zero_aligned_at(mi_heap_t* heap, void* p, size_t newsize, size_t alignment, size_t offset, bool zero) mi_attr_noexcept {
-  mi_assert(alignment > 0);
-  if (alignment <= sizeof(uintptr_t) && offset==0) return _mi_heap_realloc_zero(heap,p,newsize,zero,NULL,NULL);
+  mi_assert(alignment > 0 && _mi_is_power_of_two(alignment));
+  if mi_unlikely(alignment == 0 || !_mi_is_power_of_two(alignment)) { // require power-of-two (see <https://en.cppreference.com/w/c/memory/aligned_alloc>)
+    #if MI_DEBUG > 0
+    _mi_error_message(EOVERFLOW, "aligned allocation requires the alignment to be a power-of-two (size %zu, alignment %zu, offset %zu)\n", newsize, alignment, offset);
+    #endif
+    return NULL;
+  }
+  if (alignment <= sizeof(uintptr_t) && offset==0) return _mi_heap_realloc_zero(heap,p,newsize,zero,NULL,NULL); 
   if (p == NULL) return mi_heap_malloc_zero_aligned_at(heap,newsize,alignment,offset,zero,NULL);
   size_t size = mi_usable_size(p);
-  if (newsize <= size && newsize >= (size - (size / 2))
-      && (((uintptr_t)p + offset) % alignment) == 0) {
+  if (newsize <= size && newsize >= (size - (size / 2)) && (((uintptr_t)p + offset) & (alignment-1)) == 0) {
     return p;  // reallocation still fits, is aligned and not more than 25% waste
   }
   else {

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -293,7 +293,12 @@ void* _mi_heap_realloc_zero(mi_heap_t* heap, void* p, size_t newsize, bool zero,
     if (usable_pre!=NULL) { *usable_pre = 0; }
   }
   else {    
-    page = mi_validate_ptr_page(p,"mi_realloc");  
+    page = mi_validate_ptr_page(p,"mi_realloc"); 
+    if mi_unlikely(page==NULL) {  // invalid pointer
+      if (usable_pre!=NULL) { *usable_pre = 0; }
+      if (usable_post!=NULL) { *usable_post = 0; }  
+      return NULL;
+    } 
     size = _mi_usable_size(p,page);
     if (usable_pre!=NULL) { *usable_pre = mi_page_usable_block_size(page); }    
   }

--- a/src/free.c
+++ b/src/free.c
@@ -70,17 +70,16 @@ mi_block_t* _mi_page_ptr_unalign(const mi_page_t* page, const void* p) {
   return (mi_block_t*)((uintptr_t)p - adjust);
 }
 
-#if MI_SECURE>=3
-static inline mi_block_t* mi_cast_ptr_to_block(const mi_page_t* page, const void* p) {
+static inline mi_block_t* mi_validate_block_from_ptr( const mi_page_t* page, const void* p ) {
+  mi_assert(_mi_page_ptr_unalign(page,p) == (mi_block_t*)p); // should never be an interior pointer
+  #if MI_SECURE > 0
+  // in secure mode we always unalign to guard against free-ing interior pointers
   return _mi_page_ptr_unalign(page,p);
-}
-#else
-static inline mi_block_t* mi_cast_ptr_to_block(const mi_page_t* page, const void* p) {
-  MI_UNUSED_RELEASE(page);
-  mi_assert_internal(_mi_page_ptr_unalign(page,p) == (mi_block_t*)p);
+  #else
+  MI_UNUSED(page);
   return (mi_block_t*)p;
+  #endif
 }
-#endif
 
 // forward declaration for a MI_GUARDED build
 #if MI_GUARDED
@@ -104,7 +103,7 @@ static inline bool mi_block_check_unguard(mi_page_t* page, mi_block_t* block, vo
 // free a local pointer  (page parameter comes first for better codegen)
 static void mi_decl_noinline mi_free_generic_local(mi_page_t* page, mi_segment_t* segment, void* p) mi_attr_noexcept {
   MI_UNUSED(segment);
-  mi_block_t* const block = (mi_page_has_aligned(page) ? _mi_page_ptr_unalign(page, p) : mi_cast_ptr_to_block(page,p));
+  mi_block_t* const block = (mi_page_has_aligned(page) ? _mi_page_ptr_unalign(page, p) : mi_validate_block_from_ptr(page,p));
   const bool was_guarded = mi_block_check_unguard(page, block, p);
   mi_free_block_local(page, block, was_guarded, true /* track stats */, true /* check for a full page */);
 }
@@ -172,7 +171,7 @@ static inline void mi_free_ex(void* p, size_t* usable) mi_attr_noexcept
   if mi_likely(is_local) {                        // thread-local free?
     if mi_likely(page->flags.full_aligned == 0) { // and it is not a full page (full pages need to move from the full bin), nor has aligned blocks (aligned blocks need to be unaligned)
       // thread-local, aligned, and not a full page
-      mi_block_t* const block = mi_cast_ptr_to_block(page,p);
+      mi_block_t* const block = mi_validate_block_from_ptr(page,p);
       mi_free_block_local(page, block, false /* is guarded */, true /* track stats */, false /* no need to check if the page is full */);
     }
     else {
@@ -358,7 +357,7 @@ static inline mi_page_t* mi_validate_ptr_page(const void* p, const char* msg) {
 static inline size_t _mi_usable_size(const void* p, const mi_page_t* page) mi_attr_noexcept {
   if mi_unlikely(page==NULL) return 0;
   if mi_likely(!mi_page_has_aligned(page)) {
-    const mi_block_t* block = mi_cast_ptr_to_block(page,p);
+    const mi_block_t* block = mi_validate_block_from_ptr(page,p);
     return mi_page_usable_size_of(page, block, false /* is guarded */);
   }
   else {

--- a/src/free.c
+++ b/src/free.c
@@ -329,9 +329,10 @@ static size_t mi_decl_noinline mi_page_usable_aligned_size_of(const mi_page_t* p
   const mi_block_t* block = _mi_page_ptr_unalign(page, p);
   const bool is_guarded = mi_block_ptr_is_guarded(block,p);
   const size_t size = mi_page_usable_size_of(page, block, is_guarded);
-  const ptrdiff_t adjust = (uint8_t*)p - (uint8_t*)block;
-  mi_assert_internal(adjust >= 0 && (size_t)adjust <= size);
-  const size_t aligned_size = (size - adjust);  
+  mi_assert_internal((void*)p >= (void*)block);
+  const size_t adjust = (uint8_t*)p - (uint8_t*)block;
+  mi_assert_internal(adjust <= size);
+  const size_t aligned_size = (adjust <= size ? size - adjust : 0);  // size can be zero if the padding is corrupted
   return aligned_size;
 }
 

--- a/src/free.c
+++ b/src/free.c
@@ -70,6 +70,18 @@ mi_block_t* _mi_page_ptr_unalign(const mi_page_t* page, const void* p) {
   return (mi_block_t*)((uintptr_t)p - adjust);
 }
 
+#if MI_SECURE>=3
+static inline mi_block_t* mi_cast_ptr_to_block(const mi_page_t* page, const void* p) {
+  return _mi_page_ptr_unalign(page,p);
+}
+#else
+static inline mi_block_t* mi_cast_ptr_to_block(const mi_page_t* page, const void* p) {
+  MI_UNUSED_RELEASE(page);
+  mi_assert_internal(_mi_page_ptr_unalign(page,p) == (mi_block_t*)p);
+  return (mi_block_t*)p;
+}
+#endif
+
 // forward declaration for a MI_GUARDED build
 #if MI_GUARDED
 static void mi_block_unguard(mi_page_t* page, mi_block_t* block, void* p); // forward declaration
@@ -92,7 +104,7 @@ static inline bool mi_block_check_unguard(mi_page_t* page, mi_block_t* block, vo
 // free a local pointer  (page parameter comes first for better codegen)
 static void mi_decl_noinline mi_free_generic_local(mi_page_t* page, mi_segment_t* segment, void* p) mi_attr_noexcept {
   MI_UNUSED(segment);
-  mi_block_t* const block = (mi_page_has_aligned(page) ? _mi_page_ptr_unalign(page, p) : (mi_block_t*)p);
+  mi_block_t* const block = (mi_page_has_aligned(page) ? _mi_page_ptr_unalign(page, p) : mi_cast_ptr_to_block(page,p));
   const bool was_guarded = mi_block_check_unguard(page, block, p);
   mi_free_block_local(page, block, was_guarded, true /* track stats */, true /* check for a full page */);
 }
@@ -160,7 +172,7 @@ static inline void mi_free_ex(void* p, size_t* usable) mi_attr_noexcept
   if mi_likely(is_local) {                        // thread-local free?
     if mi_likely(page->flags.full_aligned == 0) { // and it is not a full page (full pages need to move from the full bin), nor has aligned blocks (aligned blocks need to be unaligned)
       // thread-local, aligned, and not a full page
-      mi_block_t* const block = (mi_block_t*)p;
+      mi_block_t* const block = mi_cast_ptr_to_block(page,p);
       mi_free_block_local(page, block, false /* is guarded */, true /* track stats */, false /* no need to check if the page is full */);
     }
     else {
@@ -346,7 +358,7 @@ static inline mi_page_t* mi_validate_ptr_page(const void* p, const char* msg) {
 static inline size_t _mi_usable_size(const void* p, const mi_page_t* page) mi_attr_noexcept {
   if mi_unlikely(page==NULL) return 0;
   if mi_likely(!mi_page_has_aligned(page)) {
-    const mi_block_t* block = (const mi_block_t*)p;
+    const mi_block_t* block = mi_cast_ptr_to_block(page,p);
     return mi_page_usable_size_of(page, block, false /* is guarded */);
   }
   else {

--- a/src/init.c
+++ b/src/init.c
@@ -112,7 +112,7 @@ mi_decl_cache_align const mi_heap_t _mi_heap_empty = {
   false,            // can reclaim
   0,                // tag
   #if MI_GUARDED
-  0, 0, 0, 1,       // count is 1 so we never write to it (see `internal.h:mi_heap_malloc_use_guarded`)
+  1, 0, 0, 1,       // min>max and count is 1 so we never write to it (see `internal.h:mi_heap_malloc_use_guarded`)
   #endif
   MI_SMALL_PAGES_EMPTY,
   MI_PAGE_QUEUES_EMPTY

--- a/src/page.c
+++ b/src/page.c
@@ -542,7 +542,7 @@ void _mi_heap_collect_retired(mi_heap_t* heap, bool force) {
 
 static void mi_page_free_list_extend_secure(mi_heap_t* const heap, mi_page_t* const page, const size_t bsize, const size_t extend, mi_stats_t* const stats) {
   MI_UNUSED(stats);
-  #if (MI_SECURE<=2)
+  #if (MI_SECURE<2)
   mi_assert_internal(page->free == NULL);
   mi_assert_internal(page->local_free == NULL);
   #endif
@@ -600,7 +600,7 @@ static void mi_page_free_list_extend_secure(mi_heap_t* const heap, mi_page_t* co
 static mi_decl_noinline void mi_page_free_list_extend( mi_page_t* const page, const size_t bsize, const size_t extend, mi_stats_t* const stats)
 {
   MI_UNUSED(stats);
-  #if (MI_SECURE <= 2)
+  #if (MI_SECURE < 2)
   mi_assert_internal(page->free == NULL);
   mi_assert_internal(page->local_free == NULL);
   #endif
@@ -641,7 +641,7 @@ static mi_decl_noinline void mi_page_free_list_extend( mi_page_t* const page, co
 // extra test in malloc? or cache effects?)
 static bool mi_page_extend_free(mi_heap_t* heap, mi_page_t* page, mi_tld_t* tld) {
   mi_assert_expensive(mi_page_is_valid_init(page));
-  #if (MI_SECURE<=2)
+  #if (MI_SECURE<2)
   mi_assert(page->free == NULL);
   mi_assert(page->local_free == NULL);
   if (page->free != NULL) return true;

--- a/test/test-api.c
+++ b/test/test-api.c
@@ -102,6 +102,15 @@ int main(void) {
     void* p = mi_malloc(67108872);
     mi_free(p);
   };
+  #if !MI_DEBUG
+  CHECK_BODY("mi_usable_size") {   // @zoxc opus, #11
+    char* p = mi_malloc_aligned(32, 64);        // adjust = 16
+    memset(p, 0x41, mi_usable_size(p) + 24);    // smash the canary
+    size_t sz1 = mi_usable_size(p);
+    size_t sz2 = mi_malloc_usable_size(p);
+    result = (sz1==32 && sz2==33)  || (sz1==0 && sz2==0);  // depends on build    
+  }
+  #endif
 
   // ---------------------------------------------------
   // Extended

--- a/test/test-api.c
+++ b/test/test-api.c
@@ -102,6 +102,13 @@ int main(void) {
     void* p = mi_malloc(67108872);
     mi_free(p);
   };
+  CHECK_BODY("mi_urealloc_invalid") {
+    void* p = mi_malloc(64);
+    size_t pre, post;
+    void* q = mi_urealloc((char*)p + 3, 32, &pre, &post);
+    mi_free(p);
+    result = (q==NULL || q==(uint8_t*)p+3);
+  }
 
   // ---------------------------------------------------
   // Extended

--- a/test/test-api.c
+++ b/test/test-api.c
@@ -102,15 +102,6 @@ int main(void) {
     void* p = mi_malloc(67108872);
     mi_free(p);
   };
-  #if !MI_DEBUG
-  CHECK_BODY("mi_usable_size") {   // @zoxc opus, #11
-    char* p = mi_malloc_aligned(32, 64);        // adjust = 16
-    memset(p, 0x41, mi_usable_size(p) + 24);    // smash the canary
-    size_t sz1 = mi_usable_size(p);
-    size_t sz2 = mi_malloc_usable_size(p);
-    result = (sz1==32 && sz2==33)  || (sz1==0 && sz2==0);  // depends on build    
-  }
-  #endif
 
   // ---------------------------------------------------
   // Extended


### PR DESCRIPTION
## Summary

Fixes assertion failures when extending page free lists with `MI_SECURE=2`.

At secure level 2, pages may already contain available blocks when randomized page extension occurs. The existing `MI_SECURE <= 2` assertions incorrectly required the free lists to be empty. This change limits those assertions to configurations below secure level 2.

Fixes #1342.

## Testing

- Reproduced the issue using a Debug build with `MI_SECURE=2`
  - Before the fix: 3 of 4 tests failed with free-list assertions
  - After the fix: 4 of 4 tests passed
- Ran the default Debug configuration
  - 4 of 4 tests passed