### PR TITLE
Fix missing header for UWP build

### DIFF
--- a/src/prim/windows/prim.c
+++ b/src/prim/windows/prim.c
@@ -12,6 +12,7 @@ terms of the MIT license. A copy of the license can be found in the file
 #include "mimalloc/prim.h"
 #include <stdio.h>   // fputs, stderr
 #include <stdlib.h>  // atexit
+#include <bcrypt.h>  // NTSTATUS
 
 // xbox has no console IO and cannot use LoadLibrary or GetModuleHandle
 #if !defined(WINAPI_FAMILY_PARTITION) || WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM)


### PR DESCRIPTION
Follow-up of https://github.com/microsoft/mimalloc/pull/1340

This header is necessary to build for UWP because `NTSTATUS` is not defined in `<winternl.h>` (for WINAPI_PARTITION_APP).

Not noticed before because in my private UWP patch Bcrypt is not dynamically loaded and bcrypt.h was already present.

I have now tested this exact PR and Bcrypt works with dynamic loading on UWP.

Header is need only for `NTSTATUS` definition.