### PR TITLE
fix(windows): MinGW TLS callbacks were guarded on __GCC__, which does not exist

### DIFF
--- a/src/prim/windows/prim.c
+++ b/src/prim/windows/prim.c
@@ -891,7 +891,7 @@ static void NTAPI mi_win_main(PVOID module, DWORD reason, LPVOID reserved) {
     #pragma data_seg(".CRT$XIB")
       mi_crt_callback_t _mi_crt_callback_init[] = { &mi_crt_init };
     #pragma data_seg()
-  #elif defined(__GCC__)  // mingw
+  #elif defined(__GNUC__) && !defined(_MSC_VER)  // mingw
     extern const IMAGE_TLS_DIRECTORY _tls_used;
     __attribute__((used)) static const void* const mi_tls_used_ref = &_tls_used; // pull in the CRT tls
     __attribute__((used, section(".CRT$XLB"))) PIMAGE_TLS_CALLBACK _mi_tls_callback_pre = &mi_tls_attach;
@@ -988,7 +988,7 @@ static void NTAPI mi_win_main(PVOID module, DWORD reason, LPVOID reserved) {
     #pragma data_seg(".CRT$XLY")
       PIMAGE_TLS_CALLBACK _mi_tls_callback_post[] = { &mi_tls_detach };
     #pragma data_seg()
-  #elif defined(__GCC__)  // mingw
+  #elif defined(__GNUC__) && !defined(_MSC_VER)  // mingw
     extern const IMAGE_TLS_DIRECTORY _tls_used;
     __attribute__((used)) static const void* const mi_tls_used_ref = &_tls_used; // pull in the CRT tls
     __attribute__((used, section(".CRT$XLB"))) PIMAGE_TLS_CALLBACK _mi_tls_callback_pre  = &mi_tls_attach;
@@ -1062,7 +1062,7 @@ static void NTAPI mi_win_main(PVOID module, DWORD reason, LPVOID reserved) {
     #pragma data_seg(".CRT$XLY")
     PIMAGE_TLS_CALLBACK _mi_tls_callback_post[] = { &mi_win_main_detach };
     #pragma data_seg()
-  #elif defined(__GCC__)  // mingw
+  #elif defined(__GNUC__) && !defined(_MSC_VER)  // mingw
     extern const IMAGE_TLS_DIRECTORY _tls_used;
     __attribute__((used)) static const void* const mi_tls_used_ref = &_tls_used; // pull in the CRT tls
     __attribute__((used, section(".CRT$XLB"))) PIMAGE_TLS_CALLBACK _mi_tls_callback_pre  = &mi_tls_attach;


### PR DESCRIPTION
## The defect

All three `MI_WIN_INIT_USE_*` blocks in `src/prim/windows/prim.c` (lines ~894, ~991, ~1065) guard the MinGW path on:

```c
#elif defined(__GCC__)  // mingw
```

GCC does not predefine `__GCC__` — it predefines `__GNUC__`. All three branches are dead, so under MinGW **no TLS callback is registered**, `DLL_THREAD_DETACH` never fires, and `_mi_thread_done` never runs.

This makes `60c4f031` ("add mingw windows support") a no-op, and `1c2661a8` ("remove v1/v2 mingw fix") removed the older fallback — so current `dev3` leaks per-thread state on every thread exit under MinGW. It exits 0 and surfaces only as growing commit, or as OOM on a smaller machine.

## Verified, not inferred

On this commit (`1f06f694`), GCC 12.2 / MinGW-w64 x86_64:

```
$ gcc -dM -E - </dev/null | grep -c __GCC__
0
$ gcc -dM -E - </dev/null | grep -w __GNUC__
#define __GNUC__ 12
```

and a probe containing `#ifdef __GCC__ / #error` compiles clean — the branch is never selected.

## Measurement

400 thread create/join rounds, each thread doing 64 malloc/free. Committed bytes relative to round 20. **Same commit, same machine, differing only in this one token:**

| threads | stock (`__GCC__`) | with `__GNUC__` |
|--------:|------------------:|----------------:|
| 100 | +5,900 KiB | +84 KiB |
| 200 | +13,208 KiB | +188 KiB |
| 300 | +16,992 KiB | +300 KiB |
| 400 | +16,992 KiB | +384 KiB |

Runs were interleaved and the stock arm re-run afterwards to rule out measurement order; it reproduced to within 36 KiB.

## The fix

`defined(__GNUC__) && !defined(_MSC_VER)` in all three blocks. The `_MSC_VER` clause is there so clang-cl — which defines `__GNUC__` while targeting the MSVC ABI — keeps taking the MSVC path above rather than falling into the MinGW one.

## Provenance

Found while bumping a downstream pin past `bcee5a88`. `60c4f031` credits [zackees/mimalloc-pprof#56](https://github.com/zackees/mimalloc-pprof/issues/56) — this is the same fix, reported back because the guard typo means the adopted version never took effect. The one-token divergence has been carried downstream since, with MinGW CI green on it.

Happy to split into three commits or reword if you'd prefer.
