### PR TITLE
fix: bootstrap the library in mi_heap_new and mi_subproc_new

### DIFF
--- a/src/heap.c
+++ b/src/heap.c
@@ -156,6 +156,13 @@ mi_heap_t* _mi_heap_new_for_subproc(mi_subproc_t* subproc, mi_arena_id_t exclusi
 }
 
 mi_heap_t* mi_heap_new_in_arena(mi_arena_id_t exclusive_arena_id) {
+  // `mi_heap_new` may be the very first mimalloc call in a process, in which case the
+  // main heap does not exist yet and `_mi_heap_new_for_subproc` would allocate from a
+  // NULL `subproc->heap_main`. On platforms with a library constructor something has
+  // always initialized it earlier, which is why this only shows up on Windows.
+  // `mi_thread_init` is the same idempotent bootstrap the allocation path performs
+  // (it calls `mi_process_init` in turn).
+  mi_thread_init();
   return _mi_heap_new_for_subproc(_mi_subproc(), exclusive_arena_id, false);
 }
 

--- a/src/init.c
+++ b/src/init.c
@@ -466,6 +466,9 @@ mi_subproc_id_t mi_subproc_current(void) {
 }
 
 mi_subproc_id_t mi_subproc_new(void) {
+  // As in `mi_heap_new_in_arena`: this can be the first mimalloc call in a process, and
+  // `_mi_meta_zalloc` below allocates out of the parent's main heap, which must exist.
+  mi_thread_init();
   static _Atomic(size_t) subproc_total_count;
   mi_subproc_t* const parent = _mi_subproc();
   mi_memid_t memid;


### PR DESCRIPTION
## The defect

`mi_heap_new` and `mi_subproc_new` can each be the very first mimalloc call in a process. When they are, the main heap does not exist yet:

- `mi_heap_new_in_arena` → `_mi_heap_new_for_subproc` allocates from a NULL `subproc->heap_main`.
- `mi_subproc_new` → `_mi_meta_zalloc(parent, ...)` allocates out of the parent's main heap, which is likewise not there.

On platforms with a library constructor, something has always initialized the allocator earlier — which is why this only surfaces on Windows. Same class as #1341 (`free(NULL)` before init).

## The fix

`mi_thread_init()` is the idempotent bootstrap the allocation path already performs, and it calls `mi_process_init()` in turn. Both call sites just need to do what a first `malloc` would have done.

## Measurement

On this commit (`1f06f694`), MinGW-w64 GCC 12.2 x86_64, configured exactly as `.github/workflows/test.yaml` does for its `basic` matrix entry (`-DCMAKE_BUILD_TYPE=Debug -DMI_DEBUG_FULL=ON`):

**Before**

```
67% tests passed, 2 tests failed out of 6

The following tests FAILED:
   3 - test-stress-heaps     (Exit code 0xc0000409)
   4 - test-stress-subprocs  (Exit code 0xc0000409)
```

**After**

```
100% tests passed, 0 tests failed out of 6
```

`0xc0000409` is Windows fail-fast, so these are hard aborts rather than assertion failures. Configure and build are clean in both cases — the difference is entirely at runtime.

## Why this has gone unnoticed

Both failing tests are already in the repository and pass under MSVC. There is no MinGW job in CI, so nothing exercises the configuration in which the missing bootstrap is reachable.

That is worth mentioning because it is the root cause of a small cluster: the MinGW TLS-callback support added in `60c4f031` is also currently inert, because it guards on `__GCC__` — which no compiler defines — rather than `__GNUC__`. That one is #1349. I would be happy to follow up with a MinGW CI job once these are in; it would be red today, so it should land after the fixes rather than before.

Happy to split this into two commits, or reword, if you would prefer.
