### PR TITLE
fix: page/page_bins/page_committed stats underflow in release builds

### DIFF
--- a/src/page.c
+++ b/src/page.c
@@ -321,8 +321,8 @@ static mi_page_t* mi_page_fresh_alloc(mi_heap_t* heap, mi_page_queue_t* pq, size
   const size_t full_block_size = (pq == NULL || mi_page_is_huge(page) ? mi_page_block_size(page) : block_size); // see also: mi_segment_huge_page_alloc
   mi_assert_internal(full_block_size >= block_size);
   mi_page_init(heap, page, full_block_size, heap->tld);
-  mi_heap_stat_increase(heap, pages, 1);
-  mi_heap_stat_increase(heap, page_bins[_mi_page_stats_bin(page)], 1);
+  _mi_stat_increase(&heap->tld->stats.pages, 1);
+  _mi_stat_increase(&heap->tld->stats.page_bins[_mi_page_stats_bin(page)], 1);
   if (pq != NULL) { mi_page_queue_push(heap, pq, page); }
   mi_assert_expensive(_mi_page_is_valid(page));
   return page;
@@ -701,7 +701,7 @@ static bool mi_page_extend_free(mi_heap_t* heap, mi_page_t* page, mi_tld_t* tld)
   }
   // enable the new free list
   page->capacity += (uint16_t)extend;
-  mi_stat_increase(tld->stats.page_committed, extend * bsize);
+  _mi_stat_increase(&tld->stats.page_committed, extend * bsize);
   mi_assert_expensive(mi_page_is_valid_init(page));
   return true;
 }


### PR DESCRIPTION
### Problem

The increments for `pages`, `page_bins[]` and `page_committed` go through the `MI_STAT`-gated macros, while the matching decrements call the unconditional `_mi_stat_*` functions:

| counter | increment | decrement |
|---|---|---|
| `pages` | `src/page.c:324` `mi_heap_stat_increase` — gated | `src/segment.c:1042` — unconditional |
| `page_bins[]` | `src/page.c:325` — gated | `src/segment.c:1043` — unconditional |
| `page_committed` | `src/page.c:704` `mi_stat_increase` — gated | `src/segment.c:1041` — unconditional |

`MI_STAT` defaults to `0` whenever `MI_DEBUG == 0` (`types.h`), so in a release build `mi_stat_increase` expands to `((void)0)` while the decrements still run. Any workload that repeatedly allocates and frees a page drives these counters negative.

It surfaces with objects larger than `MI_MEDIUM_OBJ_SIZE_MAX` (64 KiB), because those get a page that is released on `free`, so the unmatched decrement runs every iteration. Small and medium pages are retained and rarely reach that path — which is why a repro using ordinary small allocations shows nothing.

### Reproduction

```c
#include <stdlib.h>
#include <string.h>
int main(void) {
    for (int i = 0; i < 800; i++) { void* p = malloc(1 << 20); memset(p, i, 4096); free(p); }
    return 0;
}
```

```
before:   touched   64.2 KiB   64.2 KiB  -799.9 MiB
            pages    0          0          -800

after:    touched    1.1 MiB  800.1 MiB   121.3 KiB
            pages   14        813          13
```

Also reproduces with a **static link and direct `mi_malloc`/`mi_free`** (no override, no interposition): `touched current = -750.0 MiB`, `pages current = -800`. So it is not override- or platform-specific.

### Fix

Make the three increments unconditional, matching their decrements. Three lines in `src/page.c`.

### Testing

- `ctest` 4/4 pass on the patched tree.
- Verified on macOS 26.5.2 / arm64 (Apple clang 21.0.0), against `main` @ c683b7c6.
- The v3 line (`main3` / `dev3`) does not contain these call sites, so this targets `main` only.

### Relation to #1350

I filed #1350 describing this as a Darwin `DYLD_INSERT_LIBRARIES` interpose asymmetry — "`free` is interposed but `malloc` is not". **That diagnosis was wrong**, and I'll correct the issue. `malloc` is interposed at every size (`mi_is_in_heap_region` returns 1 and `mi_usable_size`/`malloc_size` are correct at 1 MiB); the pointers were always mimalloc's. The negative counters are this stats bug, and the allocation-size dependence is why @daanx could not reproduce it.
