### PR TITLE
Fix RISC-V thread ID lookup

### DIFF
--- a/include/mimalloc/prim.h
+++ b/include/mimalloc/prim.h
@@ -141,7 +141,7 @@ void _mi_prim_thread_associate_default_heap(mi_heap_t* heap);
 // but unfortunately we can not detect support reliably (see issue #883)
 // We also use it on Apple OS as we use a TLS slot for the default heap there.
 #if defined(__GNUC__) && ( \
-           (defined(__GLIBC__)   && (defined(__x86_64__) || defined(__i386__) || (defined(__arm__) && __ARM_ARCH >= 7) || defined(__aarch64__) || defined(__riscv))) \
+           (defined(__GLIBC__)   && (defined(__x86_64__) || defined(__i386__) || (defined(__arm__) && __ARM_ARCH >= 7) || defined(__aarch64__))) \
         || (defined(__APPLE__)   && (defined(__x86_64__) || defined(__aarch64__) || defined(__POWERPC__))) \
         || (defined(__BIONIC__)  && (defined(__x86_64__) || defined(__i386__) || (defined(__arm__) && __ARM_ARCH >= 7) || defined(__aarch64__))) \
         || (defined(__FreeBSD__) && (defined(__x86_64__) || defined(__i386__) || defined(__aarch64__))) \
@@ -173,10 +173,6 @@ static inline void* mi_prim_tls_slot(size_t slot) mi_attr_noexcept {
     __asm__ volatile ("mrs %0, tpidr_el0" : "=r" (tcb));
     #endif
     res = tcb[slot];
-  #elif defined(__riscv)
-    void** tcb; MI_UNUSED(ofs);
-    __asm__ volatile ("mv %0, tp" : "=r" (tcb));
-    res = tcb[slot];
   #elif defined(__APPLE__) && defined(__POWERPC__) // ppc, issue #781
     MI_UNUSED(ofs);
     res = pthread_getspecific(slot);
@@ -206,10 +202,6 @@ static inline void mi_prim_tls_slot_set(size_t slot, void* value) mi_attr_noexce
     #else
     __asm__ volatile ("mrs %0, tpidr_el0" : "=r" (tcb));
     #endif
-    tcb[slot] = value;
-  #elif defined(__riscv)
-    void** tcb; MI_UNUSED(ofs);
-    __asm__ volatile ("mv %0, tp" : "=r" (tcb));
     tcb[slot] = value;
   #elif defined(__APPLE__) && defined(__POWERPC__) // ppc, issue #781
     MI_UNUSED(ofs);
@@ -275,7 +267,7 @@ static inline void mi_prim_tls_slot_set(size_t slot, void* value) mi_attr_noexce
     #if    (defined(__GNUC__) && (__GNUC__ >= 7)  && defined(__aarch64__)) /* aarch64 for older gcc versions (issue #851) */ \
         || (defined(__GNUC__) && (__GNUC__ >= 7)  && defined(__riscv)) \
         || (defined(__GNUC__) && (__GNUC__ >= 11) && defined(__x86_64__)) \
-        || (defined(__clang_major__) && (__clang_major__ >= 14) && (defined(__aarch64__) || defined(__x86_64__)))
+        || (defined(__clang_major__) && (__clang_major__ >= 14) && (defined(__aarch64__) || defined(__x86_64__) || defined(__riscv)))
       #define MI_USE_BUILTIN_THREAD_POINTER  1
     #endif
   #endif


### PR DESCRIPTION
On glibc/RISC-V, tp points at the start of the static TLS block. The pointer itself identifies the current thread, but dereferencing it reads the contents of a thread-local variable instead. This makes mimalloc unusable on RISC-V when compiled with Clang, causing an immediate crash.

Clang defines `__GNUC__` as 4, so it did not satisfy the existing GCC version check for `__builtin_thread_pointer()`. `_mi_prim_thread_id()` therefore used `mi_prim_tls_slot(0)`, producing a mutable, non-unique ID that could make a cross-thread free take the local path and corrupt the heap.

Stop treating tp as a TLS-slot array on RISC-V and enable `__builtin_thread_pointer()` for Clang 14 and later. Toolchains that do not use the builtin fall back to the address of `_mi_heap_default`.