### PR TITLE
fix numa node count on linux: return the count, not the highest node …

### DIFF
--- a/src/prim/unix/prim.c
+++ b/src/prim/unix/prim.c
@@ -609,7 +609,7 @@ size_t _mi_prim_numa_node(void) {
 
 size_t _mi_prim_numa_node_count(void) {
   char buf[128];
-  unsigned last_found = 1;
+  unsigned last_found = 0;
   for(unsigned node = 1; node < 256; node++) {
     // enumerate node entries -- todo: it there a more efficient way to do this? (but ensure there is no allocation)
     _mi_snprintf(buf, 127, "/sys/devices/system/node/node%u", node);
@@ -618,7 +618,7 @@ size_t _mi_prim_numa_node_count(void) {
     }
     else { last_found = node; }         // highest found node
   }
-  return last_found;
+  return last_found + 1;
 }
 
 #elif defined(__FreeBSD__) && __FreeBSD_version >= 1200000


### PR DESCRIPTION
…index

The scan starts at node1, so on a machine with nodes 0..N-1 `last_found` ends at N-1 and is returned as the count: 2 nodes reported as 1, 4 as 3. Callers use it as a bound on node ids (`numa_node % numa_count`), so the highest node gets folded onto node 0.

Return `last_found + 1`, as the Windows primitive does with `GetNumaHighestNodeNumber() + 1`.

Follow-up to 870ac856.