### PR TITLE
Add theap stats retrieval

### DIFF
--- a/include/mimalloc-stats.h
+++ b/include/mimalloc-stats.h
@@ -140,6 +140,9 @@ mi_decl_export bool    mi_heap_stats_get(mi_heap_t* heap, mi_stats_t* stats) mi_
 mi_decl_export char*   mi_heap_stats_get_json(mi_heap_t* heap, size_t buf_size, char* buf) mi_attr_noexcept;      // use mi_free to free the result if the input buf == NULL
 mi_decl_export void    mi_heap_stats_print_out(mi_heap_t* heap, mi_output_fun* out, void* arg) mi_attr_noexcept;
 
+// stats from a theap
+mi_decl_export bool    mi_theap_stats_get(mi_theap_t* theap, mi_stats_t* stats) mi_attr_noexcept;
+
 // stats from a subprocess and its heaps aggregated
 mi_decl_export bool    mi_subproc_stats_get(mi_subproc_id_t subproc_id, mi_stats_t* stats) mi_attr_noexcept;
 mi_decl_export char*   mi_subproc_stats_get_json(mi_subproc_id_t subproc_id, size_t buf_size, char* buf) mi_attr_noexcept;      // use mi_free to free the result if the input buf == NULL

--- a/src/stats.c
+++ b/src/stats.c
@@ -464,6 +464,10 @@ static const mi_stats_t* mi_heap_get_stats(mi_heap_t* heap) {
               else return mi_stats_merge_theap_to_heap(theap);
 }
 
+static const mi_stats_t* mi_theap_get_stats(mi_theap_t* theap) {
+  return &theap->stats;
+}
+
 // deprecated
 void mi_stats_reset(void) mi_attr_noexcept {
   if (!mi_theap_is_initialized(_mi_theap_default())) return;
@@ -623,6 +627,9 @@ bool mi_heap_stats_get(mi_heap_t* heap, mi_stats_t* stats) mi_attr_noexcept {
   return mi_stats_copy(stats, mi_heap_get_stats(heap));
 }
 
+bool mi_theap_stats_get(mi_theap_t* theap, mi_stats_t* stats) mi_attr_noexcept {
+  return mi_stats_copy(stats, mi_theap_get_stats(theap));
+}
 
 static bool mi_cdecl mi_heap_aggregate_visitor(mi_heap_t* heap, void* arg) {
   mi_stats_t* stats = (mi_stats_t*)arg;


### PR DESCRIPTION
theaps already track stats internally - expose them for those who'd like to make use of them (for example, to track the current thread's allocations).