### PR TITLE
Configure monthly Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]


### PR DESCRIPTION
## Summary

Configure monthly Dependabot updates for GitHub Actions. Minor and patch updates are grouped together, while major updates remain separate.

## Coverage

The root directory covers all three GitHub Actions workflows. The four Dockerfiles use `scratch` or untagged base images, so they do not contain versions that Dependabot can update.

## Context

PR #1368 also adds a Dependabot configuration as part of its action-pinning changes. That configuration runs weekly and groups every update type. This focused alternative uses the monthly schedule and minor-and-patch grouping from the fleet policy.

## Validation

- Validated against the Dependabot v2 JSON schema
- Verified the configured directory and all three workflow files
- Confirmed the diff contains only `.github/dependabot.yml`