### PR TITLE
Allow for C mode building w/ MSVC or clang-cl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,7 +205,7 @@ if(CMAKE_C_COMPILER_ID STREQUAL "Clang" AND CMAKE_C_COMPILER_FRONTEND_VARIANT ST
 endif()
 
 # force C++ compilation with msvc or clang-cl to use modern C++ atomics
-if(CMAKE_C_COMPILER_ID MATCHES "MSVC|Intel" OR MI_CLANG_CL)
+if((CMAKE_C_COMPILER_ID MATCHES "MSVC|Intel" OR MI_CLANG_CL) AND NOT MI_NO_USE_CXX)
   set(MI_USE_CXX "ON")
 elseif(MI_DEBUG_UBSAN AND CMAKE_BUILD_TYPE MATCHES "Debug")  # ubsan needs C++
   set(MI_USE_CXX "ON")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -667,7 +667,9 @@ if(CMAKE_C_COMPILER_ID MATCHES "AppleClang|Clang|GNU|Intel" AND NOT CMAKE_SYSTEM
 endif()
 
 if (MSVC AND MSVC_VERSION GREATER_EQUAL 1914) # vs2017+
-  list(APPEND mi_cflags /Zc:__cplusplus)
+  if(MI_USE_CXX)
+    list(APPEND mi_cflags /Zc:__cplusplus)
+  endif()
   if(MI_OPT_ARCH AND NOT MI_CLANG_CL)
     if(MI_ARCH STREQUAL "x64")
       set(MI_OPT_ARCH_FLAGS "/arch:AVX2")


### PR DESCRIPTION
`MI_NO_USE_CXX` is presumably there to allow C mode building on MSVC or clang-cl, but it had no effect in some cases.