### PR TITLE
workflows: More tests for clang-cl, C mode, C++ mode

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,6 +21,7 @@ jobs:
       matrix:
         tests: [basic,extra]
         os: [windows-latest, macos-latest, ubuntu-latest, macos-14, macos-15-intel, ubuntu-22.04-arm, windows-11-arm]
+        c_or_cxx: [c, cxx]
         exclude:
           - os: macos-14
             tests: extra
@@ -45,21 +46,45 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
+      # Choose MI_USE_CXX/MI_NO_USE_CXX values
+      - name: Compute CMake args
+        id: cmake_args
+        shell: bash
+        run: |
+          CMAKE_CXX_OPT_C="-DMI_USE_CXX=OFF -DMI_NO_USE_CXX=ON"
+          CMAKE_CXX_OPT_CXX="-DMI_USE_CXX=ON -DMI_NO_USE_CXX=OFF"
+          # On MSVC, C++ mode is default, so there C mode explicitly disables C++.
+          # Everywhere else, C mode is default, so explicitly enable C
+          if [ "${{ matrix.c_or_cxx }}" = "cxx" ]; then
+            CMAKE_CXX_OPT_GCC=$CMAKE_CXX_OPT_CXX
+            CMAKE_CXX_OPT_MSVC=
+          else # Default to C mode
+            CMAKE_CXX_OPT_GCC=
+            CMAKE_CXX_OPT_MSVC=$CMAKE_CXX_OPT_C
+          fi
+          echo "CMAKE_CXX_OPT_GCC=$CMAKE_CXX_OPT_GCC" >> $GITHUB_OUTPUT
+          echo "CMAKE_CXX_OPT_MSVC=$CMAKE_CXX_OPT_MSVC" >> $GITHUB_OUTPUT
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            echo "CMAKE_CXX_OPT_DEFAULT=$CMAKE_CXX_OPT_MSVC" >> $GITHUB_OUTPUT
+          else
+            echo "CMAKE_CXX_OPT_DEFAULT=$CMAKE_CXX_OPT_GCC" >> $GITHUB_OUTPUT
+          fi
+
       # Basic
       - name: Debug
         if: matrix.tests == 'basic'
         run: |
           env
-          cmake . -B out/debug -DCMAKE_BUILD_TYPE=Debug -DMI_DEBUG=FULL
-          cmake --build out/debug --parallel 4 --config Debug
-          ctest --test-dir out/debug --verbose --timeout 240 -C Debug
+          cmake . -B out/debug-${{ matrix.c_or_cxx }} -DCMAKE_BUILD_TYPE=Debug -DMI_DEBUG=FULL ${{ steps.cmake_args.outputs.CMAKE_CXX_OPT_DEFAULT }}
+          cmake --build out/debug-${{ matrix.c_or_cxx }} --parallel 4 --config Debug
+          ctest --test-dir out/debug-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Debug
 
       - name: Release
         if: matrix.tests == 'basic'
         run: |
-          cmake . -B out/release -DCMAKE_BUILD_TYPE=Release -DMI_OPT_ARCH=ON -DMI_SEE_ASM=ON
-          cmake --build out/release --parallel 4 --config Release
-          ctest --test-dir out/release --verbose --timeout 240 -C Release
+          cmake . -B out/release-${{ matrix.c_or_cxx }} -DCMAKE_BUILD_TYPE=Release -DMI_OPT_ARCH=ON -DMI_SEE_ASM=ON ${{ steps.cmake_args.outputs.CMAKE_CXX_OPT_DEFAULT }}
+          cmake --build out/release-${{ matrix.c_or_cxx }} --parallel 4 --config Release
+          ctest --test-dir out/release-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Release
 
       - name: Release, Asm
         if: matrix.tests == 'basic' && runner.os == 'Linux'
@@ -72,181 +97,110 @@ jobs:
       - name: Secure
         if: matrix.tests == 'basic'
         run: |
-          cmake . -B out/secure -DCMAKE_BUILD_TYPE=Release -DMI_SECURE=ON
-          cmake --build out/secure --parallel 4 --config Release
-          ctest --test-dir out/secure --verbose --timeout 240 -C Release
+          cmake . -B out/secure-${{ matrix.c_or_cxx }} -DCMAKE_BUILD_TYPE=Release -DMI_SECURE=ON ${{ steps.cmake_args.outputs.CMAKE_CXX_OPT_DEFAULT }}
+          cmake --build out/secure-${{ matrix.c_or_cxx }} --parallel 4 --config Release
+          ctest --test-dir out/secure-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Release
 
-      # Basic, C++
-      - name: Debug, C++
-        if: matrix.tests == 'basic' && runner.os != 'Windows'   # windows already uses C++ by default
-        run: |
-          cmake . -B out/debug-cxx -DCMAKE_BUILD_TYPE=Debug -DMI_DEBUG=FULL -DMI_USE_CXX=ON
-          cmake --build out/debug-cxx --parallel 8 --config Debug
-          ctest --test-dir out/debug-cxx --verbose --timeout 240 -C Debug
-
-      - name: Release, C++
-        if: matrix.tests == 'basic' && runner.os != 'Windows'      # windows already uses C++ by default
-        run: |
-          cmake . -B out/release-cxx -DCMAKE_BUILD_TYPE=Release -DMI_OPT_ARCH=ON -DMI_USE_CXX=ON
-          cmake --build out/release-cxx --parallel 8 --config Release
-          ctest --test-dir out/release-cxx --verbose --timeout 240 -C Release
-
-      # Extra Windows: MI_NO_USE_CXX, x86, clang-cl, and clang
-      - name: Debug, MI_NO_USE_CXX
+      # Extra Windows: x86, clang-cl, and clang
+      - name: Debug
         if: matrix.tests == 'extra' && runner.os == 'Windows'
         run: |
-          cmake . -B out/debug-nocxx -DCMAKE_BUILD_TYPE=Debug -DMI_DEBUG=FULL -DMI_NO_USE_CXX=ON
-          cmake --build out/debug-nocxx --parallel 8 --config Debug
-          ctest --test-dir out/debug-nocxx --verbose --timeout 240 -C Debug
+          cmake . -B out/debug-${{ matrix.c_or_cxx }} -DCMAKE_BUILD_TYPE=Debug -DMI_DEBUG=FULL ${{ steps.cmake_args.outputs.CMAKE_CXX_OPT_MSVC }}
+          cmake --build out/debug-${{ matrix.c_or_cxx }} --parallel 8 --config Debug
+          ctest --test-dir out/debug-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Debug
 
-      - name: Release, MI_NO_USE_CXX
+      - name: Release
         if: matrix.tests == 'extra' && runner.os == 'Windows'
         run: |
-          cmake . -B out/release-nocxx -DCMAKE_BUILD_TYPE=Release -DMI_OPT_ARCH=ON -DMI_NO_USE_CXX=ON
-          cmake --build out/release-nocxx --parallel 8 --config Release
-          ctest --test-dir out/release-nocxx --verbose --timeout 240 -C Release
+          cmake . -B out/release-${{ matrix.c_or_cxx }} -DCMAKE_BUILD_TYPE=Release -DMI_OPT_ARCH=ON ${{ steps.cmake_args.outputs.CMAKE_CXX_OPT_MSVC }}
+          cmake --build out/release-${{ matrix.c_or_cxx }} --parallel 8 --config Release
+          ctest --test-dir out/release-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Release
 
       - name: Debug, Win32
         if: matrix.tests == 'extra' && runner.os == 'Windows'
         run: |
-          cmake . -B out/debug-x86 -DCMAKE_BUILD_TYPE=Debug -A Win32
-          cmake --build out/debug-x86 --parallel 4 --config Debug
-          ctest --test-dir out/debug-x86 --verbose --timeout 240 -C Debug
-
-      - name: Debug, Win32, MI_NO_USE_CXX
-        if: matrix.tests == 'extra' && runner.os == 'Windows'
-        run: |
-          cmake . -B out/debug-x86-nocxx -DCMAKE_BUILD_TYPE=Debug -DMI_NO_USE_CXX=ON -A Win32
-          cmake --build out/debug-x86-nocxx --parallel 4 --config Debug
-          ctest --test-dir out/debug-x86-nocxx --verbose --timeout 240 -C Debug
+          cmake . -B out/debug-x86-${{ matrix.c_or_cxx }} -DCMAKE_BUILD_TYPE=Debug -A Win32 ${{ steps.cmake_args.outputs.CMAKE_CXX_OPT_MSVC }}
+          cmake --build out/debug-x86-${{ matrix.c_or_cxx }} --parallel 4 --config Debug
+          ctest --test-dir out/debug-x86-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Debug
 
       - name: Release, Win32
         if: matrix.tests == 'extra' && runner.os == 'Windows'
         run: |
-          cmake . -B out/release-x86 -DCMAKE_BUILD_TYPE=Release -A Win32
-          cmake --build out/release-x86 --parallel 4 --config Release
-          ctest --test-dir out/release-x86 --verbose --timeout 240 -C Release
-
-      - name: Release, Win32, MI_NO_USE_CXX
-        if: matrix.tests == 'extra' && runner.os == 'Windows'
-        run: |
-          cmake . -B out/release-x86-nocxx -DCMAKE_BUILD_TYPE=Release -DMI_NO_USE_CXX=ON -A Win32
-          cmake --build out/release-x86-nocxx --parallel 4 --config Release
-          ctest --test-dir out/release-x86-nocxx --verbose --timeout 240 -C Release
+          cmake . -B out/release-x86-${{ matrix.c_or_cxx }} -DCMAKE_BUILD_TYPE=Release -A Win32 ${{ steps.cmake_args.outputs.CMAKE_CXX_OPT_MSVC }}
+          cmake --build out/release-x86-${{ matrix.c_or_cxx }} --parallel 4 --config Release
+          ctest --test-dir out/release-x86-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Release
 
       - name: Debug, Win32, clang-cl
         if: matrix.tests == 'extra' && runner.os == 'Windows'
         run: |
-          cmake . -B out/debug-x86-clang-cl -DCMAKE_BUILD_TYPE=Debug -A Win32 -T ClangCl
-          cmake --build out/debug-x86-clang-cl --parallel 4 --config Debug
-          ctest --test-dir out/debug-x86-clang-cl --verbose --timeout 240 -C Debug
-
-      - name: Debug, Win32, clang-cl, MI_NO_USE_CXX
-        if: matrix.tests == 'extra' && runner.os == 'Windows'
-        run: |
-          cmake . -B out/debug-x86-clang-cl-nocxx -DCMAKE_BUILD_TYPE=Debug -DMI_NO_USE_CXX=ON -A Win32 -T ClangCl
-          cmake --build out/debug-x86-clang-cl-nocxx --parallel 4 --config Debug
-          ctest --test-dir out/debug-x86-clang-cl-nocxx --verbose --timeout 240 -C Debug
+          cmake . -B out/debug-x86-clang-cl-${{ matrix.c_or_cxx }} -DCMAKE_BUILD_TYPE=Debug -A Win32 -T ClangCl ${{ steps.cmake_args.outputs.CMAKE_CXX_OPT_MSVC }}
+          cmake --build out/debug-x86-clang-cl-${{ matrix.c_or_cxx }} --parallel 4 --config Debug
+          ctest --test-dir out/debug-x86-clang-cl-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Debug
 
       - name: Release, Win32, clang-cl
         if: matrix.tests == 'extra' && runner.os == 'Windows'
         run: |
-          cmake . -B out/release-x86-clang-cl -DCMAKE_BUILD_TYPE=Release -A Win32 -T ClangCl
-          cmake --build out/release-x86-clang-cl --parallel 4 --config Release
-          ctest --test-dir out/release-x86-clang-cl --verbose --timeout 240 -C Release
-
-      - name: Release, Win32, clang-cl, MI_NO_USE_CXX
-        if: matrix.tests == 'extra' && runner.os == 'Windows'
-        run: |
-          cmake . -B out/release-x86-clang-cl-nocxx -DCMAKE_BUILD_TYPE=Release -DMI_NO_USE_CXX=ON -A Win32 -T ClangCl
-          cmake --build out/release-x86-clang-cl-nocxx --parallel 4 --config Release
-          ctest --test-dir out/release-x86-clang-cl-nocxx --verbose --timeout 240 -C Release
+          cmake . -B out/release-x86-clang-cl-${{ matrix.c_or_cxx }} -DCMAKE_BUILD_TYPE=Release -A Win32 -T ClangCl ${{ steps.cmake_args.outputs.CMAKE_CXX_OPT_MSVC }}
+          cmake --build out/release-x86-clang-cl-${{ matrix.c_or_cxx }} --parallel 4 --config Release
+          ctest --test-dir out/release-x86-clang-cl-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Release
 
       - name: Debug, Windows, clang-cl
         if: matrix.tests == 'extra' && runner.os == 'Windows'
         run: |
-          cmake . -B out/debug-clang-cl -DCMAKE_BUILD_TYPE=Debug -T ClangCl
-          cmake --build out/debug-clang-cl --parallel 4 --config Debug
-          ctest --test-dir out/debug-clang-cl --verbose --timeout 240 -C Debug
-
-      - name: Debug, Windows, clang-cl, MI_NO_USE_CXX
-        if: matrix.tests == 'extra' && runner.os == 'Windows'
-        run: |
-          cmake . -B out/debug-clang-cl-nocxx -DCMAKE_BUILD_TYPE=Debug -DMI_NO_USE_CXX=ON -T ClangCl
-          cmake --build out/debug-clang-cl-nocxx --parallel 4 --config Debug
-          ctest --test-dir out/debug-clang-cl-nocxx --verbose --timeout 240 -C Debug
+          cmake . -B out/debug-clang-cl-${{ matrix.c_or_cxx }} -DCMAKE_BUILD_TYPE=Debug -T ClangCl ${{ steps.cmake_args.outputs.CMAKE_CXX_OPT_MSVC }}
+          cmake --build out/debug-clang-cl-${{ matrix.c_or_cxx }} --parallel 4 --config Debug
+          ctest --test-dir out/debug-clang-cl-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Debug
 
       - name: Release, Windows, clang-cl
         if: matrix.tests == 'extra' && runner.os == 'Windows'
         run: |
-          cmake . -B out/release-clang-cl -DCMAKE_BUILD_TYPE=Release -T ClangCl
-          cmake --build out/release-clang-cl --parallel 4 --config Release
-          ctest --test-dir out/release-clang-cl --verbose --timeout 240 -C Release
-
-      - name: Release, Windows, clang-cl, MI_NO_USE_CXX
-        if: matrix.tests == 'extra' && runner.os == 'Windows'
-        run: |
-          cmake . -B out/release-clang-cl-nocxx -DCMAKE_BUILD_TYPE=Release -DMI_NO_USE_CXX=ON -T ClangCl
-          cmake --build out/release-clang-cl-nocxx --parallel 4 --config Release
-          ctest --test-dir out/release-clang-cl-nocxx --verbose --timeout 240 -C Release
+          cmake . -B out/release-clang-cl-${{ matrix.c_or_cxx }} -DCMAKE_BUILD_TYPE=Release -T ClangCl ${{ steps.cmake_args.outputs.CMAKE_CXX_OPT_MSVC }}
+          cmake --build out/release-clang-cl-${{ matrix.c_or_cxx }} --parallel 4 --config Release
+          ctest --test-dir out/release-clang-cl-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Release
 
       - name: Debug, Windows, clang
         if: matrix.tests == 'extra' && runner.os == 'Windows'
         run: |
-          cmake . -B out/debug-clang -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang
-          cmake --build out/debug-clang --parallel 4 --config Debug
-          ctest --test-dir out/debug-clang --verbose --timeout 240 -C Debug
-
-      - name: Debug, Windows, clang, MI_NO_USE_CXX
-        if: matrix.tests == 'extra' && runner.os == 'Windows'
-        run: |
-          cmake . -B out/debug-clang-nocxx -DCMAKE_BUILD_TYPE=Debug -DMI_NO_USE_CXX=ON -DCMAKE_C_COMPILER=clang
-          cmake --build out/debug-clang-nocxx --parallel 4 --config Debug
-          ctest --test-dir out/debug-clang-nocxx --verbose --timeout 240 -C Debug
+          cmake . -B out/debug-clang-${{ matrix.c_or_cxx }} -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang ${{ steps.cmake_args.outputs.CMAKE_CXX_OPT_MSVC }}
+          cmake --build out/debug-clang-${{ matrix.c_or_cxx }} --parallel 4 --config Debug
+          ctest --test-dir out/debug-clang-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Debug
 
       - name: Release, Windows, clang
         if: matrix.tests == 'extra' && runner.os == 'Windows'
         run: |
-          cmake . -B out/release-clang -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang
-          cmake --build out/release-clang --parallel 4 --config Release
-          ctest --test-dir out/release-clang --verbose --timeout 240 -C Release          
-
-      - name: Release, Windows, clang, MI_NO_USE_CXX
-        if: matrix.tests == 'extra' && runner.os == 'Windows'
-        run: |
-          cmake . -B out/release-clang-nocxx -DCMAKE_BUILD_TYPE=Release -DMI_NO_USE_CXX=ON -DCMAKE_C_COMPILER=clang
-          cmake --build out/release-clang-nocxx --parallel 4 --config Release
-          ctest --test-dir out/release-clang-nocxx --verbose --timeout 240 -C Release
+          cmake . -B out/release-clang-${{ matrix.c_or_cxx }} -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang ${{ steps.cmake_args.outputs.CMAKE_CXX_OPT_MSVC }}
+          cmake --build out/release-clang-${{ matrix.c_or_cxx }} --parallel 4 --config Release
+          ctest --test-dir out/release-clang-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Release
 
       # Extra, macOS fixed TLS
       - name: Debug, macOS, TLS fixed
         if: matrix.tests == 'extra' && runner.os == 'macOS'
         run: |
-          cmake . -B out/debug-tls-fixed -DCMAKE_BUILD_TYPE=Debug -DMI_TLS_MODEL_FIXED=ON
-          cmake --build out/debug-tls-fixed --parallel 4 --config Debug
-          ctest --test-dir out/debug-tls-fixed --verbose --timeout 240 -C Debug
+          cmake . -B out/debug-tls-fixed-${{ matrix.c_or_cxx }} -DCMAKE_BUILD_TYPE=Debug -DMI_TLS_MODEL_FIXED=ON ${{ steps.cmake_args.outputs.CMAKE_CXX_OPT_DEFAULT }}
+          cmake --build out/debug-tls-fixed-${{ matrix.c_or_cxx }} --parallel 4 --config Debug
+          ctest --test-dir out/debug-tls-fixed-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Debug
 
       - name: Release, macOS, TLS fixed
         if: matrix.tests == 'extra' && runner.os == 'macOS'
         run: |
-          cmake . -B out/release-tls-fixed -DCMAKE_BUILD_TYPE=Release -DMI_TLS_MODEL_FIXED=ON
-          cmake --build out/release-tls-fixed --parallel 4 --config Release
-          ctest --test-dir out/release-tls-fixed --verbose --timeout 240 -C Release
+          cmake . -B out/release-tls-fixed-${{ matrix.c_or_cxx }} -DCMAKE_BUILD_TYPE=Release -DMI_TLS_MODEL_FIXED=ON ${{ steps.cmake_args.outputs.CMAKE_CXX_OPT_DEFAULT }}
+          cmake --build out/release-tls-fixed-${{ matrix.c_or_cxx }} --parallel 4 --config Release
+          ctest --test-dir out/release-tls-fixed-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Release
 
       # Extra, Linux pthread TLS
       - name: Debug, Linux, TLS pthreads
         if: matrix.tests == 'extra' && runner.os == 'linux'
         run: |
-          cmake . -B out/debug-tls-pthreads -DCMAKE_BUILD_TYPE=Debug -DMI_TLS_MODEL_PTHREADS=ON
-          cmake --build out/debug-tls-pthreads --parallel 4 --config Debug
-          ctest --test-dir out/debug-tls-pthreads --verbose --timeout 240 -C Debug
+          cmake . -B out/debug-tls-pthreads-${{ matrix.c_or_cxx }} -DCMAKE_BUILD_TYPE=Debug -DMI_TLS_MODEL_PTHREADS=ON ${{ steps.cmake_args.outputs.CMAKE_CXX_OPT_DEFAULT }}
+          cmake --build out/debug-tls-pthreads-${{ matrix.c_or_cxx }} --parallel 4 --config Debug
+          ctest --test-dir out/debug-tls-pthreads-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Debug
 
       - name: Release, Linux, TLS pthreads
         if: matrix.tests == 'extra' && runner.os == 'linux'
         run: |
-          cmake . -B out/release-tls-pthreads -DCMAKE_BUILD_TYPE=Release -DMI_TLS_MODEL_PTHREADS=ON -DMI_SEE_ASM=ON
-          cmake --build out/release-tls-pthreads --parallel 4 --config Release
-          ctest --test-dir out/release-tls-pthreads --verbose --timeout 240 -C Release
+          cmake . -B out/release-tls-pthreads-${{ matrix.c_or_cxx }} -DCMAKE_BUILD_TYPE=Release -DMI_TLS_MODEL_PTHREADS=ON -DMI_SEE_ASM=ON ${{ steps.cmake_args.outputs.CMAKE_CXX_OPT_DEFAULT }}
+          cmake --build out/release-tls-pthreads-${{ matrix.c_or_cxx }} --parallel 4 --config Release
+          ctest --test-dir out/release-tls-pthreads-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Release
 
       - name: Release, Linux, TLS pthreads, Asm
         if: matrix.tests == 'extra' && runner.os == 'linux'
@@ -260,33 +214,26 @@ jobs:
       - name: Release, SIMD
         if: matrix.tests == 'extra'
         run: |
-          cmake . -B out/release-simd -DCMAKE_BUILD_TYPE=Release -DMI_OPT_ARCH=ON -DMI_OPT_SIMD=ON
-          cmake --build out/release-simd --parallel 8 --config Release
-          ctest --test-dir out/release-simd --verbose --timeout 240 -C Release
-
-      - name: Release, C++, SIMD
-        if: matrix.tests == 'basic' && runner.os != 'Windows' && runner.os != 'macOS'
-        run: |
-          cmake . -B out/release-cxx -DCMAKE_BUILD_TYPE=Release -DMI_OPT_ARCH=ON -DMI_OPT_SIMD=ON -DMI_USE_CXX=ON
-          cmake --build out/release-cxx --parallel 8 --config Release
-          ctest --test-dir out/release-cxx --verbose --timeout 240 -C Release
+          cmake . -B out/release-simd-${{ matrix.c_or_cxx }} -DCMAKE_BUILD_TYPE=Release -DMI_OPT_ARCH=ON -DMI_OPT_SIMD=ON ${{ steps.cmake_args.outputs.CMAKE_CXX_OPT_DEFAULT }}
+          cmake --build out/release-simd-${{ matrix.c_or_cxx }} --parallel 8 --config Release
+          ctest --test-dir out/release-simd-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Release
 
       - name: Debug, C++, clang++
-        if: matrix.tests == 'extra' && runner.os == 'Linux'
+        if: matrix.tests == 'extra' && runner.os == 'Linux' && matrix.c_or_cxx == 'cxx'
         run: |
-          CC=clang CXX=clang++ cmake . -B out/debug-clang-cxx -DCMAKE_BUILD_TYPE=Debug -DMI_DEBUG=FULL -DMI_USE_CXX=ON
-          cmake --build out/debug-clang-cxx --parallel 8 --config Debug
-          ctest --test-dir out/debug-clang-cxx --verbose --timeout 240 -C Debug
+          CC=clang CXX=clang++ cmake . -B out/debug-clang-${{ matrix.c_or_cxx }} -DCMAKE_BUILD_TYPE=Debug -DMI_DEBUG=FULL -DMI_USE_CXX=ON
+          cmake --build out/debug-clang-${{ matrix.c_or_cxx }} --parallel 8 --config Debug
+          ctest --test-dir out/debug-clang-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Debug
 
       - name: Release, C++, clang++
-        if: matrix.tests == 'extra' && runner.os == 'Linux'
+        if: matrix.tests == 'extra' && runner.os == 'Linux' && matrix.c_or_cxx == 'cxx'
         run: |
-          CC=clang CXX=clang++ cmake . -B out/release-clang-cxx -DCMAKE_BUILD_TYPE=Release -DMI_OPT_ARCH=ON -DMI_USE_CXX=ON -DMI_SEE_ASM=ON
-          cmake --build out/release-clang-cxx --parallel 8 --config Release
-          ctest --test-dir out/release-clang-cxx --verbose --timeout 240 -C Release
+          CC=clang CXX=clang++ cmake . -B out/release-clang-${{ matrix.c_or_cxx }} -DCMAKE_BUILD_TYPE=Release -DMI_OPT_ARCH=ON -DMI_USE_CXX=ON -DMI_SEE_ASM=ON
+          cmake --build out/release-clang-${{ matrix.c_or_cxx }} --parallel 8 --config Release
+          ctest --test-dir out/release-clang-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Release
 
       - name: Release, C++, clang++, Asm
-        if: matrix.tests == 'extra' && runner.os == 'Linux'
+        if: matrix.tests == 'extra' && runner.os == 'Linux' && matrix.c_or_cxx == 'cxx'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.os }}-clang-cxx-asm
@@ -295,48 +242,48 @@ jobs:
       - name: Debug, ASAN
         if: matrix.tests == 'extra' && runner.os == 'Linux'
         run: |
-          CC=clang CXX=clang++ cmake . -B out/debug-asan -DCMAKE_BUILD_TYPE=Debug -DMI_DEBUG=FULL -DMI_TRACK=ASAN
-          cmake --build out/debug-asan --parallel 8 --config Debug
-          ctest --test-dir out/debug-asan --verbose --timeout 240 -C Debug
+          CC=clang CXX=clang++ cmake . -B out/debug-asan-${{ matrix.c_or_cxx }} -DCMAKE_BUILD_TYPE=Debug -DMI_DEBUG=FULL -DMI_TRACK=ASAN ${{ steps.cmake_args.outputs.CMAKE_CXX_OPT_DEFAULT }}
+          cmake --build out/debug-asan-${{ matrix.c_or_cxx }} --parallel 8 --config Debug
+          ctest --test-dir out/debug-asan-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Debug
 
       - name: Debug, UBSAN
         if: matrix.tests == 'extra' && runner.os == 'Linux'
         run: |
-          CC=clang CXX=clang++ cmake . -B out/debug-ubsan -DCMAKE_BUILD_TYPE=Debug -DMI_DEBUG=FULL -DMI_DEBUG_UBSAN=ON
-          cmake --build out/debug-ubsan --parallel 8 --config Debug
-          ctest --test-dir out/debug-ubsan --verbose --timeout 240 -C Debug
+          CC=clang CXX=clang++ cmake . -B out/debug-ubsan-${{ matrix.c_or_cxx }} -DCMAKE_BUILD_TYPE=Debug -DMI_DEBUG=FULL -DMI_DEBUG_UBSAN=ON ${{ steps.cmake_args.outputs.CMAKE_CXX_OPT_DEFAULT }}
+          cmake --build out/debug-ubsan-${{ matrix.c_or_cxx }} --parallel 8 --config Debug
+          ctest --test-dir out/debug-ubsan-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Debug
 
       - name: Debug, TSAN
         if: matrix.tests == 'extra' && runner.os == 'Linux'
         run: |
-          CC=clang CXX=clang++ cmake . -B out/debug-tsan -DCMAKE_BUILD_TYPE=Debug -DMI_DEBUG=FULL -DMI_DEBUG_TSAN=ON
-          cmake --build out/debug-tsan --parallel 8 --config Debug
-          ctest --test-dir out/debug-tsan --verbose --timeout 240 -C Debug
+          CC=clang CXX=clang++ cmake . -B out/debug-tsan-${{ matrix.c_or_cxx }} -DCMAKE_BUILD_TYPE=Debug -DMI_DEBUG=FULL -DMI_DEBUG_TSAN=ON ${{ steps.cmake_args.outputs.CMAKE_CXX_OPT_DEFAULT }}
+          cmake --build out/debug-tsan-${{ matrix.c_or_cxx }} --parallel 8 --config Debug
+          ctest --test-dir out/debug-tsan-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Debug
 
       - name: Debug, Guarded
         if: matrix.tests == 'extra' && runner.os != 'macOS'
         run: |
-          cmake . -B out/debug-guarded -DCMAKE_BUILD_TYPE=Debug -DMI_DEBUG=FULL -DMI_GUARDED=ON
-          cmake --build out/debug-guarded --parallel 8 --config Debug
-          ctest --test-dir out/debug-guarded --verbose --timeout 240 -C Debug
+          cmake . -B out/debug-guarded-${{ matrix.c_or_cxx }} -DCMAKE_BUILD_TYPE=Debug -DMI_DEBUG=FULL -DMI_GUARDED=ON ${{ steps.cmake_args.outputs.CMAKE_CXX_OPT_DEFAULT }}
+          cmake --build out/debug-guarded-${{ matrix.c_or_cxx }} --parallel 8 --config Debug
+          ctest --test-dir out/debug-guarded-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Debug
         env:
           MIMALLOC_GUARDED_SAMPLE_RATE: 10
 
       - name: Release, Guarded
         if: matrix.tests == 'extra' && runner.os == 'Linux' && startsWith(github.ref_name,'dev3')
         run: |
-          cmake . -B out/release-guarded -DCMAKE_BUILD_TYPE=Release -DMI_OPT_ARCH=ON -DMI_GUARDED=ON
-          cmake --build out/release-guarded --parallel 8 --config Release
-          ctest --test-dir out/release-guarded --verbose --timeout 240 -C Release
+          cmake . -B out/release-guarded-${{ matrix.c_or_cxx }} -DCMAKE_BUILD_TYPE=Release -DMI_OPT_ARCH=ON -DMI_GUARDED=ON ${{ steps.cmake_args.outputs.CMAKE_CXX_OPT_DEFAULT }}
+          cmake --build out/release-guarded-${{ matrix.c_or_cxx }} --parallel 8 --config Release
+          ctest --test-dir out/release-guarded-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Release
         env:
           MIMALLOC_GUARDED_SAMPLE_RATE: 10
 
       - name: Debug, Secure Full
         if: matrix.tests == 'extra' && runner.os != 'macOS'
         run: |
-          cmake . -B out/debug-secure-full -DCMAKE_BUILD_TYPE=Debug -DMI_DEBUG=FULL -DMI_SECURE=FULL
-          cmake --build out/debug-secure-full --parallel 8 --config Debug
-          ctest --test-dir out/debug-secure-full --verbose --timeout 240 -C Debug        
+          cmake . -B out/debug-secure-full-${{ matrix.c_or_cxx }} -DCMAKE_BUILD_TYPE=Debug -DMI_DEBUG=FULL -DMI_SECURE=FULL ${{ steps.cmake_args.outputs.CMAKE_CXX_OPT_DEFAULT }}
+          cmake --build out/debug-secure-full-${{ matrix.c_or_cxx }} --parallel 8 --config Debug
+          ctest --test-dir out/debug-secure-full-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Debug
 
       # MSYS2 mingw64
       - name: mingw-ucrt64 x64, Setup
@@ -355,17 +302,17 @@ jobs:
         shell: msys2 {0}
         run: |
           env
-          cmake . -B out/debug-mingw-ucrt64-x64 -DCMAKE_BUILD_TYPE=Debug -DMI_DEBUG=FULL
-          cmake --build out/debug-mingw-ucrt64-x64 --parallel 4 --config Debug
-          ctest --test-dir out/debug-mingw-ucrt64-x64 --verbose --timeout 240 -C Debug
+          cmake . -B out/debug-mingw-ucrt64-x64-${{ matrix.c_or_cxx }} -DCMAKE_BUILD_TYPE=Debug -DMI_DEBUG=FULL ${{ steps.cmake_args.outputs.CMAKE_CXX_OPT_GCC }}
+          cmake --build out/debug-mingw-ucrt64-x64-${{ matrix.c_or_cxx }} --parallel 4 --config Debug
+          ctest --test-dir out/debug-mingw-ucrt64-x64-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Debug
 
       - name: mingw-ucrt64 x64, Release
         if: matrix.tests == 'mingw-ucrt64'
         shell: msys2 {0}
         run: |
-          cmake . -B out/release-mingw-ucrt64-x64 -DCMAKE_BUILD_TYPE=Release  -DMI_OPT_ARCH=ON
-          cmake --build out/release-mingw-ucrt64-x64 --parallel 4 --config Release
-          ctest --test-dir out/release-mingw-ucrt64-x64 --verbose --timeout 240 -C Release
+          cmake . -B out/release-mingw-ucrt64-x64-${{ matrix.c_or_cxx }} -DCMAKE_BUILD_TYPE=Release  -DMI_OPT_ARCH=ON ${{ steps.cmake_args.outputs.CMAKE_CXX_OPT_GCC }}
+          cmake --build out/release-mingw-ucrt64-x64-${{ matrix.c_or_cxx }} --parallel 4 --config Release
+          ctest --test-dir out/release-mingw-ucrt64-x64-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Release
 
 
       # VM: FreeBSD (arm64 and x64)
@@ -385,27 +332,27 @@ jobs:
         shell: freebsd-arm64 {0}
         run: |
           export MI_TEST_LIGHT=1
-          cmake . -B out/debug-arm64 -G Ninja -DCMAKE_BUILD_TYPE=Debug -DMI_DEBUG=FULL
-          cmake --build out/debug-arm64 --parallel 4 --config Debug
-          ctest --test-dir out/debug-arm64 --verbose --timeout 240 -C Debug
+          cmake . -B out/debug-arm64-${{ matrix.c_or_cxx }} -G Ninja -DCMAKE_BUILD_TYPE=Debug -DMI_DEBUG=FULL ${{ steps.cmake_args.outputs.CMAKE_CXX_OPT_DEFAULT }}
+          cmake --build out/debug-arm64-${{ matrix.c_or_cxx }} --parallel 4 --config Debug
+          ctest --test-dir out/debug-arm64-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Debug
 
       - name: FreeBSD arm64, Release
         if: matrix.tests == 'freebsd-arm64'
         shell: freebsd-arm64 {0}
         run: |
           export MI_TEST_LIGHT=1
-          cmake . -B out/release-arm64 -G Ninja -DCMAKE_BUILD_TYPE=Release  -DMI_OPT_ARCH=ON
-          cmake --build out/release-arm64 --parallel 4 --config Release
-          ctest --test-dir out/release-arm64 --verbose --timeout 240 -C Release
+          cmake . -B out/release-arm64-${{ matrix.c_or_cxx }} -G Ninja -DCMAKE_BUILD_TYPE=Release  -DMI_OPT_ARCH=ON ${{ steps.cmake_args.outputs.CMAKE_CXX_OPT_DEFAULT }}
+          cmake --build out/release-arm64-${{ matrix.c_or_cxx }} --parallel 4 --config Release
+          ctest --test-dir out/release-arm64-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Release
 
       - name: FreeBSD arm64, Secure
         if: matrix.tests == 'freebsd-arm64'
         shell: freebsd-arm64 {0}
         run: |
           export MI_TEST_LIGHT=1
-          cmake . -B out/secure-arm64 -G Ninja -DCMAKE_BUILD_TYPE=Release -DMI_SECURE=ON
-          cmake --build out/secure-arm64 --parallel 4 --config Release
-          ctest --test-dir out/secure-arm64 --verbose --timeout 240 -C Release
+          cmake . -B out/secure-arm64-${{ matrix.c_or_cxx }} -G Ninja -DCMAKE_BUILD_TYPE=Release -DMI_SECURE=ON ${{ steps.cmake_args.outputs.CMAKE_CXX_OPT_DEFAULT }}
+          cmake --build out/secure-arm64-${{ matrix.c_or_cxx }} --parallel 4 --config Release
+          ctest --test-dir out/secure-arm64-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Release
 
 
       - name: FreeBSD x64, Setup
@@ -423,25 +370,25 @@ jobs:
         if: matrix.tests == 'freebsd-x64'
         shell: freebsd-x64 {0}
         run: |
-          cmake . -B out/debug-x64 -DCMAKE_BUILD_TYPE=Debug -DMI_DEBUG=FULL
-          cmake --build out/debug-x64 --parallel 4 --config Debug
-          ctest --test-dir out/debug-x64 --verbose --timeout 240 -C Debug
+          cmake . -B out/debug-x64-${{ matrix.c_or_cxx }} -DCMAKE_BUILD_TYPE=Debug -DMI_DEBUG=FULL ${{ steps.cmake_args.outputs.CMAKE_CXX_OPT_DEFAULT }}
+          cmake --build out/debug-x64-${{ matrix.c_or_cxx }} --parallel 4 --config Debug
+          ctest --test-dir out/debug-x64-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Debug
 
       - name: FreeBSD x64, Release
         if: matrix.tests == 'freebsd-x64'
         shell: freebsd-x64 {0}
         run: |
-          cmake . -B out/release-x64 -DCMAKE_BUILD_TYPE=Release  -DMI_OPT_ARCH=ON
-          cmake --build out/release-x64 --parallel 4 --config Release
-          ctest --test-dir out/release-x64 --verbose --timeout 240 -C Release
+          cmake . -B out/release-x64-${{ matrix.c_or_cxx }} -DCMAKE_BUILD_TYPE=Release  -DMI_OPT_ARCH=ON ${{ steps.cmake_args.outputs.CMAKE_CXX_OPT_DEFAULT }}
+          cmake --build out/release-x64-${{ matrix.c_or_cxx }} --parallel 4 --config Release
+          ctest --test-dir out/release-x64-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Release
 
       - name: FreeBSD x64, Secure
         if: matrix.tests == 'freebsd-x64'
         shell: freebsd-x64 {0}
         run: |
-          cmake . -B out/secure-x64 -DCMAKE_BUILD_TYPE=Release -DMI_SECURE=ON
-          cmake --build out/secure-x64 --parallel 4 --config Release
-          ctest --test-dir out/secure-x64 --verbose --timeout 240 -C Release
+          cmake . -B out/secure-x64-${{ matrix.c_or_cxx }} -DCMAKE_BUILD_TYPE=Release -DMI_SECURE=ON ${{ steps.cmake_args.outputs.CMAKE_CXX_OPT_DEFAULT }}
+          cmake --build out/secure-x64-${{ matrix.c_or_cxx }} --parallel 4 --config Release
+          ctest --test-dir out/secure-x64-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Release
 
 
       # VM: Alpine Linux with MUSL libc (riscv64 and x64)
@@ -463,17 +410,17 @@ jobs:
           MI_TEST_LIGHT: 1
         run: |
           uname -m
-          cmake . -B out/debug-riscv64 -G Ninja -DCMAKE_BUILD_TYPE=Debug -DMI_DEBUG=FULL
-          cmake --build out/debug-riscv64 --parallel 4 --config Debug
-          ctest --test-dir out/debug-riscv64 --verbose --timeout 240 -C Debug
+          cmake . -B out/debug-riscv64-${{ matrix.c_or_cxx }} -G Ninja -DCMAKE_BUILD_TYPE=Debug -DMI_DEBUG=FULL ${{ steps.cmake_args.outputs.CMAKE_CXX_OPT_DEFAULT }}
+          cmake --build out/debug-riscv64-${{ matrix.c_or_cxx }} --parallel 4 --config Debug
+          ctest --test-dir out/debug-riscv64-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Debug
 
       - name: Alpine riscv64, Release
         if: matrix.tests == 'alpine-riscv64'
         shell: alpine-riscv64.sh {0}
         run: |
-          cmake . -B out/release-riscv64 -G Ninja -DCMAKE_BUILD_TYPE=Release -DMI_OPT_ARCH=ON -DMI_SEE_ASM=ON
-          cmake --build out/release-riscv64 --parallel 4 --config Release
-          ctest --test-dir out/release-riscv64 --verbose --timeout 240 -C Release
+          cmake . -B out/release-riscv64-${{ matrix.c_or_cxx }} -G Ninja -DCMAKE_BUILD_TYPE=Release -DMI_OPT_ARCH=ON -DMI_SEE_ASM=ON ${{ steps.cmake_args.outputs.CMAKE_CXX_OPT_DEFAULT }}
+          cmake --build out/release-riscv64-${{ matrix.c_or_cxx }} --parallel 4 --config Release
+          ctest --test-dir out/release-riscv64-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Release
 
       - name: Alpine risc64, Asm
         if: matrix.tests == 'alpine-riscv64'
@@ -486,9 +433,9 @@ jobs:
         if: matrix.tests == 'alpine-riscv64'
         shell: alpine-riscv64.sh {0}
         run: |
-          cmake . -B out/secure-riscv64 -G Ninja -DCMAKE_BUILD_TYPE=Release -DMI_SECURE=ON
-          cmake --build out/secure-riscv64 --parallel 4 --config Release
-          ctest --test-dir out/secure-riscv64 --verbose --timeout 240 -C Release
+          cmake . -B out/secure-riscv64-${{ matrix.c_or_cxx }} -G Ninja -DCMAKE_BUILD_TYPE=Release -DMI_SECURE=ON ${{ steps.cmake_args.outputs.CMAKE_CXX_OPT_DEFAULT }}
+          cmake --build out/secure-riscv64-${{ matrix.c_or_cxx }} --parallel 4 --config Release
+          ctest --test-dir out/secure-riscv64-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Release
 
 
       - name: Alpine x64, Setup
@@ -505,25 +452,25 @@ jobs:
         if: matrix.tests == 'alpine-x64'
         shell: alpine-x64.sh {0}
         run: |
-          cmake . -B out/debug-x64 -DCMAKE_BUILD_TYPE=Debug -DMI_DEBUG=FULL
-          cmake --build out/debug-x64 --parallel 4 --config Debug
-          ctest --test-dir out/debug-x64 --verbose --timeout 240 -C Debug
+          cmake . -B out/debug-x64-${{ matrix.c_or_cxx }} -DCMAKE_BUILD_TYPE=Debug -DMI_DEBUG=FULL ${{ steps.cmake_args.outputs.CMAKE_CXX_OPT_DEFAULT }}
+          cmake --build out/debug-x64-${{ matrix.c_or_cxx }} --parallel 4 --config Debug
+          ctest --test-dir out/debug-x64-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Debug
 
       - name: Alpine x64, Release
         if: matrix.tests == 'alpine-x64'
         shell: alpine-x64.sh {0}
         run: |
-          cmake . -B out/release-x64 -DCMAKE_BUILD_TYPE=Release  -DMI_OPT_ARCH=ON
-          cmake --build out/release-x64 --parallel 4 --config Release
-          ctest --test-dir out/release-x64 --verbose --timeout 240 -C Release
+          cmake . -B out/release-x64-${{ matrix.c_or_cxx }} -DCMAKE_BUILD_TYPE=Release  -DMI_OPT_ARCH=ON ${{ steps.cmake_args.outputs.CMAKE_CXX_OPT_DEFAULT }}
+          cmake --build out/release-x64-${{ matrix.c_or_cxx }} --parallel 4 --config Release
+          ctest --test-dir out/release-x64-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Release
 
       - name: Alpine x64, Secure
         if: matrix.tests == 'alpine-x64'
         shell: alpine-x64.sh {0}
         run: |
-          cmake . -B out/secure-x64 -DCMAKE_BUILD_TYPE=Release -DMI_SECURE=ON
-          cmake --build out/secure-x64 --parallel 4 --config Release
-          ctest --test-dir out/secure-x64 --verbose --timeout 240 -C Release
+          cmake . -B out/secure-x64-${{ matrix.c_or_cxx }} -DCMAKE_BUILD_TYPE=Release -DMI_SECURE=ON ${{ steps.cmake_args.outputs.CMAKE_CXX_OPT_DEFAULT }}
+          cmake --build out/secure-x64-${{ matrix.c_or_cxx }} --parallel 4 --config Release
+          ctest --test-dir out/secure-x64-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Release
 
       - name: Alpine arm32, Setup
         if: matrix.tests == 'alpine-arm32'
@@ -542,25 +489,25 @@ jobs:
           MI_TEST_LIGHT: 1
         run: |
           uname -m
-          cmake . -B out/debug-arm32 -DCMAKE_BUILD_TYPE=Debug -DMI_DEBUG=FULL
-          cmake --build out/debug-arm32 --parallel 4 --config Debug
-          ctest --test-dir out/debug-arm32 --verbose --timeout 240 -C Debug
+          cmake . -B out/debug-arm32-${{ matrix.c_or_cxx }} -DCMAKE_BUILD_TYPE=Debug -DMI_DEBUG=FULL ${{ steps.cmake_args.outputs.CMAKE_CXX_OPT_DEFAULT }}
+          cmake --build out/debug-arm32-${{ matrix.c_or_cxx }} --parallel 4 --config Debug
+          ctest --test-dir out/debug-arm32-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Debug
 
       - name: Alpine arm32, Release
         if: matrix.tests == 'alpine-arm32'
         shell: alpine-arm32.sh {0}
         run: |
-          cmake . -B out/release-arm32 -DCMAKE_BUILD_TYPE=Release  -DMI_OPT_ARCH=ON
-          cmake --build out/release-arm32 --parallel 4 --config Release
-          ctest --test-dir out/release-arm32 --verbose --timeout 240 -C Release
+          cmake . -B out/release-arm32-${{ matrix.c_or_cxx }} -DCMAKE_BUILD_TYPE=Release  -DMI_OPT_ARCH=ON ${{ steps.cmake_args.outputs.CMAKE_CXX_OPT_DEFAULT }}
+          cmake --build out/release-arm32-${{ matrix.c_or_cxx }} --parallel 4 --config Release
+          ctest --test-dir out/release-arm32-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Release
 
       - name: Alpine arm32, Secure
         if: matrix.tests == 'alpine-arm32'
         shell: alpine-arm32.sh {0}
         run: |
-          cmake . -B out/secure-arm32 -DCMAKE_BUILD_TYPE=Release -DMI_SECURE=ON
-          cmake --build out/secure-arm32 --parallel 4 --config Release
-          ctest --test-dir out/secure-arm32 --verbose --timeout 240 -C Release
+          cmake . -B out/secure-arm32-${{ matrix.c_or_cxx }} -DCMAKE_BUILD_TYPE=Release -DMI_SECURE=ON ${{ steps.cmake_args.outputs.CMAKE_CXX_OPT_DEFAULT }}
+          cmake --build out/secure-arm32-${{ matrix.c_or_cxx }} --parallel 4 --config Release
+          ctest --test-dir out/secure-arm32-${{ matrix.c_or_cxx }} --verbose --timeout 240 -C Release
 
       # - name: Android, Setup
       #   if: matrix.tests == 'android-x64'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -134,31 +134,59 @@ jobs:
           cmake --build out/release-x86-nocxx --parallel 4 --config Release
           ctest --test-dir out/release-x86-nocxx --verbose --timeout 240 -C Release
 
+      - name: Debug, Win32, clang-cl
+        if: matrix.tests == 'extra' && runner.os == 'Windows'
+        run: |
+          cmake . -B out/debug-x86-clang-cl -DCMAKE_BUILD_TYPE=Debug -A Win32 -T ClangCl
+          cmake --build out/debug-x86-clang-cl --parallel 4 --config Debug
+          ctest --test-dir out/debug-x86-clang-cl --verbose --timeout 240 -C Debug
+
+      - name: Debug, Win32, clang-cl, MI_NO_USE_CXX
+        if: matrix.tests == 'extra' && runner.os == 'Windows'
+        run: |
+          cmake . -B out/debug-x86-clang-cl-nocxx -DCMAKE_BUILD_TYPE=Debug -DMI_NO_USE_CXX=ON -A Win32 -T ClangCl
+          cmake --build out/debug-x86-clang-cl-nocxx --parallel 4 --config Debug
+          ctest --test-dir out/debug-x86-clang-cl-nocxx --verbose --timeout 240 -C Debug
+
+      - name: Release, Win32, clang-cl
+        if: matrix.tests == 'extra' && runner.os == 'Windows'
+        run: |
+          cmake . -B out/release-x86-clang-cl -DCMAKE_BUILD_TYPE=Release -A Win32 -T ClangCl
+          cmake --build out/release-x86-clang-cl --parallel 4 --config Release
+          ctest --test-dir out/release-x86-clang-cl --verbose --timeout 240 -C Release
+
+      - name: Release, Win32, clang-cl, MI_NO_USE_CXX
+        if: matrix.tests == 'extra' && runner.os == 'Windows'
+        run: |
+          cmake . -B out/release-x86-clang-cl-nocxx -DCMAKE_BUILD_TYPE=Release -DMI_NO_USE_CXX=ON -A Win32 -T ClangCl
+          cmake --build out/release-x86-clang-cl-nocxx --parallel 4 --config Release
+          ctest --test-dir out/release-x86-clang-cl-nocxx --verbose --timeout 240 -C Release
+
       - name: Debug, Windows, clang-cl
         if: matrix.tests == 'extra' && runner.os == 'Windows'
         run: |
-          cmake . -B out/debug-clang-cl -DCMAKE_BUILD_TYPE=Debug -A Win32 -T ClangCl
+          cmake . -B out/debug-clang-cl -DCMAKE_BUILD_TYPE=Debug -T ClangCl
           cmake --build out/debug-clang-cl --parallel 4 --config Debug
           ctest --test-dir out/debug-clang-cl --verbose --timeout 240 -C Debug
 
       - name: Debug, Windows, clang-cl, MI_NO_USE_CXX
         if: matrix.tests == 'extra' && runner.os == 'Windows'
         run: |
-          cmake . -B out/debug-clang-cl-nocxx -DCMAKE_BUILD_TYPE=Debug -DMI_NO_USE_CXX=ON -A Win32 -T ClangCl
+          cmake . -B out/debug-clang-cl-nocxx -DCMAKE_BUILD_TYPE=Debug -DMI_NO_USE_CXX=ON -T ClangCl
           cmake --build out/debug-clang-cl-nocxx --parallel 4 --config Debug
           ctest --test-dir out/debug-clang-cl-nocxx --verbose --timeout 240 -C Debug
 
       - name: Release, Windows, clang-cl
         if: matrix.tests == 'extra' && runner.os == 'Windows'
         run: |
-          cmake . -B out/release-clang-cl -DCMAKE_BUILD_TYPE=Release -A Win32 -T ClangCl
+          cmake . -B out/release-clang-cl -DCMAKE_BUILD_TYPE=Release -T ClangCl
           cmake --build out/release-clang-cl --parallel 4 --config Release
           ctest --test-dir out/release-clang-cl --verbose --timeout 240 -C Release
 
       - name: Release, Windows, clang-cl, MI_NO_USE_CXX
         if: matrix.tests == 'extra' && runner.os == 'Windows'
         run: |
-          cmake . -B out/release-clang-cl-nocxx -DCMAKE_BUILD_TYPE=Release -DMI_NO_USE_CXX=ON -A Win32 -T ClangCl
+          cmake . -B out/release-clang-cl-nocxx -DCMAKE_BUILD_TYPE=Release -DMI_NO_USE_CXX=ON -T ClangCl
           cmake --build out/release-clang-cl-nocxx --parallel 4 --config Release
           ctest --test-dir out/release-clang-cl-nocxx --verbose --timeout 240 -C Release
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -113,12 +113,26 @@ jobs:
           cmake --build out/debug-clang-cl --parallel 4 --config Debug
           ctest --test-dir out/debug-clang-cl --verbose --timeout 240 -C Debug
 
+      - name: Debug, Windows, clang-cl, MI_NO_USE_CXX
+        if: matrix.tests == 'extra' && runner.os == 'Windows'
+        run: |
+          cmake . -B out/debug-clang-cl-nocxx -DCMAKE_BUILD_TYPE=Debug -DMI_NO_USE_CXX=ON -A Win32 -T ClangCl
+          cmake --build out/debug-clang-cl-nocxx --parallel 4 --config Debug
+          ctest --test-dir out/debug-clang-cl-nocxx --verbose --timeout 240 -C Debug
+
       - name: Release, Windows, clang-cl
         if: matrix.tests == 'extra' && runner.os == 'Windows'
         run: |
           cmake . -B out/release-clang-cl -DCMAKE_BUILD_TYPE=Release -A Win32 -T ClangCl
           cmake --build out/release-clang-cl --parallel 4 --config Release
           ctest --test-dir out/release-clang-cl --verbose --timeout 240 -C Release
+
+      - name: Release, Windows, clang-cl, MI_NO_USE_CXX
+        if: matrix.tests == 'extra' && runner.os == 'Windows'
+        run: |
+          cmake . -B out/release-clang-cl-nocxx -DCMAKE_BUILD_TYPE=Release -DMI_NO_USE_CXX=ON -A Win32 -T ClangCl
+          cmake --build out/release-clang-cl-nocxx --parallel 4 --config Release
+          ctest --test-dir out/release-clang-cl-nocxx --verbose --timeout 240 -C Release
 
       - name: Debug, Windows, clang
         if: matrix.tests == 'extra' && runner.os == 'Windows'
@@ -127,12 +141,26 @@ jobs:
           cmake --build out/debug-clang --parallel 4 --config Debug
           ctest --test-dir out/debug-clang --verbose --timeout 240 -C Debug
 
+      - name: Debug, Windows, clang, MI_NO_USE_CXX
+        if: matrix.tests == 'extra' && runner.os == 'Windows'
+        run: |
+          cmake . -B out/debug-clang-nocxx -DCMAKE_BUILD_TYPE=Debug -DMI_NO_USE_CXX=ON -DCMAKE_C_COMPILER=clang
+          cmake --build out/debug-clang-nocxx --parallel 4 --config Debug
+          ctest --test-dir out/debug-clang-nocxx --verbose --timeout 240 -C Debug
+
       - name: Release, Windows, clang
         if: matrix.tests == 'extra' && runner.os == 'Windows'
         run: |
           cmake . -B out/release-clang -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang
           cmake --build out/release-clang --parallel 4 --config Release
           ctest --test-dir out/release-clang --verbose --timeout 240 -C Release          
+
+      - name: Release, Windows, clang, MI_NO_USE_CXX
+        if: matrix.tests == 'extra' && runner.os == 'Windows'
+        run: |
+          cmake . -B out/release-clang-nocxx -DCMAKE_BUILD_TYPE=Release -DMI_NO_USE_CXX=ON -DCMAKE_C_COMPILER=clang
+          cmake --build out/release-clang-nocxx --parallel 4 --config Release
+          ctest --test-dir out/release-clang-nocxx --verbose --timeout 240 -C Release
 
       # Extra, macOS fixed TLS
       - name: Debug, macOS, TLS fixed

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -91,7 +91,21 @@ jobs:
           cmake --build out/release-cxx --parallel 8 --config Release
           ctest --test-dir out/release-cxx --verbose --timeout 240 -C Release
 
-      # Extra Windows: x86, clang-cl, and clang
+      # Extra Windows: MI_NO_USE_CXX, x86, clang-cl, and clang
+      - name: Debug, MI_NO_USE_CXX
+        if: matrix.tests == 'extra' && runner.os == 'Windows'
+        run: |
+          cmake . -B out/debug-nocxx -DCMAKE_BUILD_TYPE=Debug -DMI_DEBUG=FULL -DMI_NO_USE_CXX=ON
+          cmake --build out/debug-nocxx --parallel 8 --config Debug
+          ctest --test-dir out/debug-nocxx --verbose --timeout 240 -C Debug
+
+      - name: Release, MI_NO_USE_CXX
+        if: matrix.tests == 'extra' && runner.os == 'Windows'
+        run: |
+          cmake . -B out/release-nocxx -DCMAKE_BUILD_TYPE=Release -DMI_OPT_ARCH=ON -DMI_NO_USE_CXX=ON
+          cmake --build out/release-nocxx --parallel 8 --config Release
+          ctest --test-dir out/release-nocxx --verbose --timeout 240 -C Release
+
       - name: Debug, Win32
         if: matrix.tests == 'extra' && runner.os == 'Windows'
         run: |
@@ -99,12 +113,26 @@ jobs:
           cmake --build out/debug-x86 --parallel 4 --config Debug
           ctest --test-dir out/debug-x86 --verbose --timeout 240 -C Debug
 
+      - name: Debug, Win32, MI_NO_USE_CXX
+        if: matrix.tests == 'extra' && runner.os == 'Windows'
+        run: |
+          cmake . -B out/debug-x86-nocxx -DCMAKE_BUILD_TYPE=Debug -DMI_NO_USE_CXX=ON -A Win32
+          cmake --build out/debug-x86-nocxx --parallel 4 --config Debug
+          ctest --test-dir out/debug-x86-nocxx --verbose --timeout 240 -C Debug
+
       - name: Release, Win32
         if: matrix.tests == 'extra' && runner.os == 'Windows'
         run: |
           cmake . -B out/release-x86 -DCMAKE_BUILD_TYPE=Release -A Win32
           cmake --build out/release-x86 --parallel 4 --config Release
           ctest --test-dir out/release-x86 --verbose --timeout 240 -C Release
+
+      - name: Release, Win32, MI_NO_USE_CXX
+        if: matrix.tests == 'extra' && runner.os == 'Windows'
+        run: |
+          cmake . -B out/release-x86-nocxx -DCMAKE_BUILD_TYPE=Release -DMI_NO_USE_CXX=ON -A Win32
+          cmake --build out/release-x86-nocxx --parallel 4 --config Release
+          ctest --test-dir out/release-x86-nocxx --verbose --timeout 240 -C Release
 
       - name: Debug, Windows, clang-cl
         if: matrix.tests == 'extra' && runner.os == 'Windows'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -93,42 +93,42 @@ jobs:
 
       # Extra Windows: x86, clang-cl, and clang
       - name: Debug, Win32
-        if: matrix.tests == 'extra' && runner.os == 'Windows' && !endsWith(matrix.os,'arm')
+        if: matrix.tests == 'extra' && runner.os == 'Windows'
         run: |
           cmake . -B out/debug-x86 -DCMAKE_BUILD_TYPE=Debug -A Win32
           cmake --build out/debug-x86 --parallel 4 --config Debug
           ctest --test-dir out/debug-x86 --verbose --timeout 240 -C Debug
 
       - name: Release, Win32
-        if: matrix.tests == 'extra' && runner.os == 'Windows' && !endsWith(matrix.os,'arm')
+        if: matrix.tests == 'extra' && runner.os == 'Windows'
         run: |
           cmake . -B out/release-x86 -DCMAKE_BUILD_TYPE=Release -A Win32
           cmake --build out/release-x86 --parallel 4 --config Release
           ctest --test-dir out/release-x86 --verbose --timeout 240 -C Release
 
       - name: Debug, Windows, clang-cl
-        if: matrix.tests == 'extra' && runner.os == 'Windows' && !endsWith(matrix.os,'arm')
+        if: matrix.tests == 'extra' && runner.os == 'Windows'
         run: |
           cmake . -B out/debug-clang-cl -DCMAKE_BUILD_TYPE=Debug -A Win32 -T ClangCl
           cmake --build out/debug-clang-cl --parallel 4 --config Debug
           ctest --test-dir out/debug-clang-cl --verbose --timeout 240 -C Debug
 
       - name: Release, Windows, clang-cl
-        if: matrix.tests == 'extra' && runner.os == 'Windows' && !endsWith(matrix.os,'arm')
+        if: matrix.tests == 'extra' && runner.os == 'Windows'
         run: |
           cmake . -B out/release-clang-cl -DCMAKE_BUILD_TYPE=Release -A Win32 -T ClangCl
           cmake --build out/release-clang-cl --parallel 4 --config Release
           ctest --test-dir out/release-clang-cl --verbose --timeout 240 -C Release
 
       - name: Debug, Windows, clang
-        if: matrix.tests == 'extra' && runner.os == 'Windows' && !endsWith(matrix.os,'arm')
+        if: matrix.tests == 'extra' && runner.os == 'Windows'
         run: |
           cmake . -B out/debug-clang -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang
           cmake --build out/debug-clang --parallel 4 --config Debug
           ctest --test-dir out/debug-clang --verbose --timeout 240 -C Debug
 
       - name: Release, Windows, clang
-        if: matrix.tests == 'extra' && runner.os == 'Windows' && !endsWith(matrix.os,'arm')
+        if: matrix.tests == 'extra' && runner.os == 'Windows'
         run: |
           cmake . -B out/release-clang -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang
           cmake --build out/release-clang --parallel 4 --config Release


### PR DESCRIPTION
Although some build scenarios are non-default edge cases (eg C mode builds on MSVC or clang-cl), they an happen nonetheless when custom building is involved (eg via vcpkg or meson) - so expand the test cases to cover more C and C++ mode builds across the various platforms and compilers already in the test workflows.

Needs #1380 to actually build w/ C mode in some cases, and then #1379 to succeed.