### PR TITLE
fix: mi_theap_zalloc_csize zeroes its large branch

### DIFF
--- a/include/mimalloc.h
+++ b/include/mimalloc.h
@@ -409,7 +409,7 @@ static inline mi_decl_restrict void* mi_theap_malloc_csize(mi_theap_t* theap, si
   if (size <= MI_SMALL_SIZE_MAX) { return mi_theap_malloc_small(theap,size); } else { return mi_theap_malloc(theap,size); }
 }
 static inline mi_decl_restrict void* mi_theap_zalloc_csize(mi_theap_t* theap, size_t size) mi_attr_noexcept {
-  if (size <= MI_SMALL_SIZE_MAX) { return mi_theap_zalloc_small(theap,size); } else { return mi_theap_malloc(theap,size); }
+  if (size <= MI_SMALL_SIZE_MAX) { return mi_theap_zalloc_small(theap,size); } else { return mi_theap_zalloc(theap,size); }
 }
 static inline void mi_free_csize(void* p, size_t size) mi_attr_noexcept {
   if (size <= MI_SMALL_SIZE_MAX) { mi_free_small(p); } else { mi_free(p); }

--- a/test/test-api.c
+++ b/test/test-api.c
@@ -330,6 +330,24 @@ int main(void) {
     }
     result = ok;
   };
+  CHECK_BODY("zalloc-csize-large") {
+    // mi_theap_zalloc_csize must zero its large branch too: it used to
+    // delegate sizes above MI_SMALL_SIZE_MAX to the plain malloc path.
+    mi_theap_t* theap = mi_theap_get_default();
+    size_t size = MI_SMALL_SIZE_MAX + 64;
+    bool ok = true;
+    for (int round = 0; round < 16 && ok; round++) {
+      uint8_t* junk = (uint8_t*)mi_theap_malloc(theap, size);
+      memset(junk, 0xAB, size);
+      mi_free(junk);
+      uint8_t* z = (uint8_t*)mi_theap_zalloc_csize(theap, size);
+      for (size_t i = 0; i < size; i++) {
+        if (z[i] != 0) { ok = false; break; }
+      }
+      mi_free(z);
+    }
+    result = ok;
+  };
   CHECK_BODY("zalloc-aligned-small1") {
     size_t zalloc_size = MI_SMALL_SIZE_MAX / 2;
     uint8_t* p = (uint8_t*)mi_zalloc_aligned(zalloc_size, MI_MAX_ALIGN_SIZE * 2);


### PR DESCRIPTION
`mi_theap_zalloc_csize` delegates its large-size branch to `mi_theap_malloc` instead of `mi_theap_zalloc`:

```c
static inline mi_decl_restrict void* mi_theap_zalloc_csize(mi_theap_t* theap, size_t size) mi_attr_noexcept {
  if (size <= MI_SMALL_SIZE_MAX) { return mi_theap_zalloc_small(theap,size); } else { return mi_theap_malloc(theap,size); }
}
```

So a documented zeroing allocator returns uninitialized heap memory for every size above `MI_SMALL_SIZE_MAX`. Reproduced on current `dev3`: scribble a block with `0xAB`, free it, call `mi_theap_zalloc_csize` at `MI_SMALL_SIZE_MAX + 64`, and the returned block carries the old bytes. The sibling `mi_theap_malloc_csize` shows the intended pattern (small branch and large branch agree); only the zalloc variant crossed over.

One-token fix, plus a regression check in `test-api.c` that scribbles, frees, and asserts the zalloc_csize block is fully zeroed across reuse rounds. `mimalloc-test-api` passes with the fix and reports the new check red without it.
