### PR TITLE
_mi_subproc(): fall back to the main subproc when tld->subproc is not yet set

### DIFF
--- a/src/subproc.c
+++ b/src/subproc.c
@@ -102,7 +102,7 @@ bool _mi_subproc_is_main(mi_subproc_t* subproc) {
 
 mi_subproc_t* _mi_subproc(void) {
   mi_theap_t* theap = _mi_theap_default();
-  if (theap == NULL || theap->tld == NULL) {  // see issue #1289
+  if (theap == NULL || theap->tld == NULL || theap->tld->subproc == NULL) {  // see issue #1289
     return _mi_subproc_main();
   }
   else {


### PR DESCRIPTION
`_mi_subproc()` (src/subproc.c) defends against partially-initialized thread state per issue #1289:

```c
mi_theap_t* theap = _mi_theap_default();
if (theap == NULL || theap->tld == NULL) {  // see issue #1289
  return _mi_subproc_main();
}
else {
  return theap->tld->subproc;
}
```

There is a third member of the same initialization progression it does not cover: a window where the theap **and** its `tld` exist but `tld->subproc` has not been set yet.  In that window the function returns **NULL** instead of falling back to `_mi_subproc_main()`, and any caller that immediately dereferences the result for stat accounting faults.

**How we hit it (context, not required for the fix):** a malloc-override shared library whose constructor allocates before mimalloc's process/thread init has completed.  The first OS commit then runs `mi_subproc_stat_counter_increase(NULL, commit_calls, 1)` and faults at address `0x700`, which is exactly `offsetof(mi_subproc_t, stats.commit_calls)` in our build — confirmed against the faulting address register.  Any embedder whose constructor ordering puts allocation ahead of subproc wiring can reach the same window; it is not specific to our fork's extensions.

**Fix** — extend the existing guard with the missing disjunct, so the fallback covers the whole progression it already defends:

```c
if (theap == NULL || theap->tld == NULL || theap->tld->subproc == NULL) {  // see issue #1289
  return _mi_subproc_main();
}
```

This is what we run; it removed the constructor-time crash with no other change.  The fallback (`_mi_subproc_main()`) is the same one the existing guard already selects for the earlier stages of the same window, so behavior for initialized threads is unchanged.  Validated against `dev3` HEAD: clean build, `mimalloc-test-api` and `mimalloc-test-stress` pass.
