### PR TITLE
Associate the process-init thread's theap with the thread-done key

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -441,6 +441,17 @@ static void mi_thread_theaps_done(mi_tld_t* tld)
 static void mi_process_setup_auto_thread_done(void) {
   mi_atomic_do_once {
     _mi_prim_thread_init_auto_done();
+    // The thread that ran `mi_process_init` initialized its default theap before the
+    // thread-done key existed, so `_mi_theap_default_set` could not associate it
+    // (see `_mi_prim_thread_associate_default_theap`). Associate it now so that
+    // `_mi_thread_done` also runs when that thread terminates (for example when the
+    // first thread to use mimalloc is a short-lived worker thread that loaded us).
+    // Otherwise its theap stays registered in the heap with a thread id that the OS
+    // may reuse for a later thread.
+    mi_theap_t* theap = _mi_theap_default();
+    if (mi_theap_is_initialized(theap)) {
+      _mi_prim_thread_associate_default_theap(theap);
+    }
   }
 }
 


### PR DESCRIPTION
Since v3.5.0 the thread that runs `mi_process_init` never gets its theap associated with the thread-done key. `_mi_thread_init_with_heap` runs before `mi_process_setup_auto_thread_done` creates the key, so `_mi_prim_thread_associate_default_theap` is a no-op for that thread, and the call that used to fix this up afterwards (`_mi_theap_default_set(&mi_process_theap_main)`) was removed in 5d9cb381 ("remove static main theap and tld"). If that first thread exits, `_mi_thread_done` never runs for it and its theap stays registered with its thread id.

We hit this with a Node.js addon that links mimalloc statically: a worker thread loads the addon first (so the constructor runs there), exits, and the next thread that gets the same pthread TCB aborts on its first allocation in debug builds:

```
mimalloc: assertion failed: at "src/init.c":326, _mi_thread_init_with_heap
  assertion: "theap==NULL"
```

Release builds skip the assert and just leak the dead thread's theap and pages. v3.4.5 is fine, v3.5.1 still has it. The v2 line does the equivalent association in `_mi_heap_set_default_direct(&_mi_heap_main)`.

The fix associates the current theap with the key right after creating it, if it is already initialized. Teardown of the static main theap already works once the destructor fires (`_mi_tld_detach_theaps`, static memid skipped, `thread_id` set to `MI_THREADID_INVALID`).

`ctest` passes before and after; the existing tests never let the first thread exit, so they don't catch this.

<details>
<summary>Standalone repro (mimalloc built with <code>-DCMAKE_BUILD_TYPE=Debug -DMI_BUILD_SHARED=ON</code>)</summary>

```c
#define _GNU_SOURCE
#include <dlfcn.h>
#include <pthread.h>
#include <stdio.h>
#include <stdlib.h>

typedef void* (*mi_malloc_fn)(size_t);
typedef void  (*mi_free_fn)(void*);

static const char*  lib_path;
static mi_malloc_fn mi_malloc_p;
static mi_free_fn   mi_free_p;

static void alloc_and_free(void) {
  void* p[4];
  for (int i = 0; i < 4; i++) p[i] = mi_malloc_p((size_t)64 << i);
  for (int i = 0; i < 4; i++) mi_free_p(p[i]);
}

// T1: loads mimalloc (constructor -> mi_process_init runs here), allocates, exits.
static void* t1(void* arg) {
  (void)arg;
  printf("T1 pthread_self=%p  (dlopen + first mi_malloc happen here, then T1 exits)\n", (void*)pthread_self());
  void* h = dlopen(lib_path, RTLD_NOW);  // never dlclose'd: the library stays loaded
  if (h == NULL) { fprintf(stderr, "dlopen: %s\n", dlerror()); exit(2); }
  mi_malloc_p = (mi_malloc_fn)dlsym(h, "mi_malloc");
  mi_free_p   = (mi_free_fn)dlsym(h, "mi_free");
  if (mi_malloc_p == NULL || mi_free_p == NULL) { fprintf(stderr, "dlsym: %s\n", dlerror()); exit(2); }
  alloc_and_free();
  return (void*)pthread_self();
}

// T2: a fresh thread; with the same stack size glibc's stack cache hands it T1's TCB.
static void* t2(void* arg) {
  (void)arg;
  printf("T2 pthread_self=%p  (calling mi_malloc on this thread)\n", (void*)pthread_self());
  fflush(stdout);
  alloc_and_free();
  return (void*)pthread_self();
}

int main(int argc, char** argv) {
  if (argc < 2) { fprintf(stderr, "usage: %s <libmimalloc.so>\n", argv[0]); return 2; }
  lib_path = argv[1];
  pthread_attr_t attr;
  pthread_attr_init(&attr);
  pthread_attr_setstacksize(&attr, (size_t)4 << 20);  // same size for every thread
  pthread_t th; void* t1_self; void* t2_self;
  if (pthread_create(&th, &attr, t1, NULL) != 0 || pthread_join(th, &t1_self) != 0) return 2;
  int n = 0;
  do {  // usually the very first T2 reuses T1's TCB; loop just in case
    n++;
    if (pthread_create(&th, &attr, t2, NULL) != 0 || pthread_join(th, &t2_self) != 0) return 2;
  } while (t2_self != t1_self && n < 64);
  printf("%s (after %d T2 thread%s)\n", t2_self == t1_self ? "T2 reused T1's TCB" : "no TCB reuse observed", n, n == 1 ? "" : "s");
  printf("OK\n");
  return 0;
}
```

```
cc -g first-thread-done-repro.c -o first-thread-done-repro -ldl -lpthread
./first-thread-done-repro build/libmimalloc-debug.so
```

Before: T1 and T2 print the same `pthread_self`, then the assertion above. After: `OK`.
</details>
